### PR TITLE
Redirect based on email input

### DIFF
--- a/landing_page_app/templates/components/base.html
+++ b/landing_page_app/templates/components/base.html
@@ -1,3 +1,6 @@
+{% from 'govuk_frontend_jinja/components/input/macro.html' import govukInput %}
+{%- from 'govuk_frontend_jinja/components/button/macro.html' import govukButton -%}
+
 {% extends 'govuk_frontend_jinja/template.html' %}
 
 {% block pageTitle %}
@@ -50,3 +53,16 @@
     <script src="{{ url_for('static', filename='javascript/govuk-frontend-4.3.0.min.js') }}"></script>
     <script>window.GOVUKFrontend.initAll()</script>
 {% endblock bodyEnd %}
+
+{% block content %}
+{% with messages = get_flashed_messages() %}
+{% if messages %}
+{% for message in messages %}
+{{ govukErrorSummary({
+'titleText': "There is a problem",
+'errorList': [{ 'text': message}]
+}) }}
+{% endfor %}
+{% endif %}
+{% endwith %}
+{% endblock %}

--- a/landing_page_app/templates/pages/external-collaborator.html
+++ b/landing_page_app/templates/pages/external-collaborator.html
@@ -1,0 +1,30 @@
+{% extends "components/base.html" %}
+
+{% block pageTitle %}
+    External Collaborators
+{% endblock %}
+
+{% block content %}
+    <h1 class="govuk-heading-xl">External collaborators</h1>
+    <p class="govuk-body">
+        The email address {{email}} is not from a pre-approved domain. 
+        Please request access via the following:
+    
+    <ul class="govuk-list govuk-list--bullet">
+        <li>Create a request on the Operations Engineering team Slack channel <a
+        href="https://mojdt.slack.com/archives/C01BUKJSZD4" class="govuk-link">
+        #ask-operations-engineering</a>. Please state which GitHub Organisation/s you 
+        would like to join and your email address.</li>
+        <br>
+        <li>For access to a Ministry of Justice GitHub Organisation repository see <a class="govuk-link"
+        href="https://github.com/ministryofjustice/github-collaborators">https://github.com/ministryofjustice/github-collaborators</a>.</li>
+        <br>
+        <li>For access to an MoJ Analytical Services GitHub Organisation repository see <a class="govuk-link"
+        href="https://github.com/moj-analytical-services/github-outside-collaborators">https://github.com/moj-analytical-services/github-outside-collaborators</a>.</li>
+
+    </ul>
+
+    </p>
+    <a href="/" class="govuk-back-link">Back</a>
+
+{% endblock %}

--- a/landing_page_app/templates/pages/join-as-only-option.html
+++ b/landing_page_app/templates/pages/join-as-only-option.html
@@ -1,0 +1,17 @@
+{% extends "components/base.html" %}
+
+{% block pageTitle %}
+    EMAIL REDIRECT
+{% endblock %}
+
+{% block content %}
+    <h1 class="govuk-heading-xl">Email domain preapproved for AS only: {{email}}</h1>
+
+    <p class="govuk-body">
+        If you require further assistance contact us on the Operations-Engineering team Slack channel <a
+            href="https://mojdt.slack.com/archives/C01BUKJSZD4" class="govuk-link">#ask-operations-engineering</a>.
+    </p>
+
+    <a href="/" class="govuk-back-link">Back</a>
+
+{% endblock %}

--- a/landing_page_app/templates/pages/join-both-moj-and-as-option.html
+++ b/landing_page_app/templates/pages/join-both-moj-and-as-option.html
@@ -1,0 +1,17 @@
+{% extends "components/base.html" %}
+
+{% block pageTitle %}
+    EMAIL REDIRECT
+{% endblock %}
+
+{% block content %}
+    <h1 class="govuk-heading-xl">Email domain preapproved for both MoJ and AS: {{email}}</h1>
+
+    <p class="govuk-body">
+        If you require further assistance contact us on the Operations-Engineering team Slack channel <a
+            href="https://mojdt.slack.com/archives/C01BUKJSZD4" class="govuk-link">#ask-operations-engineering</a>.
+    </p>
+
+    <a href="/" class="govuk-back-link">Back</a>
+
+{% endblock %}

--- a/landing_page_app/templates/pages/join-github.html
+++ b/landing_page_app/templates/pages/join-github.html
@@ -5,6 +5,7 @@
 {% endblock %}
 
 {% block content %}
+  {{ super() }}
     <h1 class="govuk-heading-xl">Joining GitHub</h1>
 
     <p class="govuk-body">
@@ -14,9 +15,20 @@
         <li><a class="govuk-link" href="https://github.com/moj-analytical-services">MoJ Analytical Services</a></li>
     </ul>
     </p>
-    <p class="govuk-body">
-        Please see below for instructions on how to join.
-    </p>
+
+    <form action="/check-email-address" method="POST">
+        {{ govukInput({
+            'id': 'email_address', 
+            'name': 'emailAddress', 
+            'classes': 'govuk-!-width-one-third',
+            'label': {'text': 'Please provide the email address you want to join with:'}, 
+        })  }}
+    
+        {{ govukButton({
+            'text': "Next"
+        }) }}
+
+    </form>
 
     <br>
 
@@ -58,30 +70,6 @@
 
     <p class="govuk-body">
         Complete this <a class="govuk-link" href="/login">form</a> to gain access.
-    </p>
-
-    <h3 class="govuk-heading-l">Other Users</h3>
-
-    <p class="govuk-body">
-        Create a request on the Operations-Engineering team Slack channel <a
-            href="https://mojdt.slack.com/archives/C01BUKJSZD4" class="govuk-link">#ask-operations-engineering</a>.
-        Please provide which GitHub Organisation/s you would like to join and your email address.
-    </p>
-
-    <h3 class="govuk-heading-l">External Users</h3>
-
-    <p class="govuk-body">
-        External users can get access to an Organization repository as an Outside Collaborator.
-    </p>
-
-    <p class="govuk-body">
-        For access to a Ministry of Justice GitHub Organization repository see <a class="govuk-link"
-                                                                                  href="https://github.com/ministryofjustice/github-collaborators">https://github.com/ministryofjustice/github-collaborators</a>.
-    </p>
-
-    <p class="govuk-body">
-        For access to an MoJ Analytical Services GitHub Organization repository see <a class="govuk-link"
-                                                                                       href="https://github.com/moj-analytical-services/github-outside-collaborators">https://github.com/moj-analytical-services/github-outside-collaborators</a>.
     </p>
 
     <a href="/" class="govuk-back-link">Back</a>

--- a/landing_page_app/templates/pages/join-moj-only-option.html
+++ b/landing_page_app/templates/pages/join-moj-only-option.html
@@ -1,0 +1,17 @@
+{% extends "components/base.html" %}
+
+{% block pageTitle %}
+    EMAIL REDIRECT
+{% endblock %}
+
+{% block content %}
+    <h1 class="govuk-heading-xl">Email domain preapproved for MoJ only: {{email}}</h1>
+
+    <p class="govuk-body">
+        If you require further assistance contact us on the Operations-Engineering team Slack channel <a
+            href="https://mojdt.slack.com/archives/C01BUKJSZD4" class="govuk-link">#ask-operations-engineering</a>.
+    </p>
+
+    <a href="/" class="govuk-back-link">Back</a>
+
+{% endblock %}


### PR DESCRIPTION
This PR is to redirect the user from the GitHub joiner landing page automatically based on the user email input. This means the user no longer has to read a lot of information and make a decision (which may be wrong). From the email address we can determine which organisations they have pre-approved access to or not and direct them appropriately.