### PR TITLE
✨ Add Path Explaining SSO to Digital Justice Users

### DIFF
--- a/join_github_app/main/views.py
+++ b/join_github_app/main/views.py
@@ -1,17 +1,14 @@
 import logging
 import re
 
-from flask import Blueprint, current_app, redirect, render_template, request, session, flash, session, url_for
+from flask import (Blueprint, current_app, flash, redirect, render_template,
+                   request, session, url_for)
 
+from join_github_app.main.config.constants import ALLOWED_EMAIL_DOMAINS
 from join_github_app.main.middleware.auth import requires_auth
-from join_github_app.main.scripts.join_github_form_auth0_user import (
-    JoinGithubFormAuth0User,
-)
 from join_github_app.main.middleware.utils import is_valid_email_pattern
-
-from join_github_app.main.config.constants import (
-    ALLOWED_EMAIL_DOMAINS,
-)
+from join_github_app.main.scripts.join_github_form_auth0_user import \
+    JoinGithubFormAuth0User
 
 logger = logging.getLogger(__name__)
 
@@ -43,9 +40,9 @@ def join_github():
 @main.route("/outside-collaborator")
 def outside_collaborator():
     return render_template(
-                "pages/outside-collaborator.html",
-                email=session["email"],
-            )
+        "pages/outside-collaborator.html",
+        email=session["email"],
+    )
 
 
 @main.route("/select-organisations", methods=["GET", "POST"])
@@ -62,6 +59,12 @@ def select_organisations():
 
 @main.route("/join-selection")
 def join_selection():
+    if "digital.justice.gov.uk" in session["email"]:
+        return render_template(
+            "pages/digital-justice-user.html",
+            org_selection=session["org_selection"],
+            email=session["email"],
+        )
     return render_template(
         "pages/join-selection.html",
         org_selection=session["org_selection"],

--- a/join_github_app/main/views.py
+++ b/join_github_app/main/views.py
@@ -59,17 +59,15 @@ def select_organisations():
 
 @main.route("/join-selection")
 def join_selection():
-    if "digital.justice.gov.uk" in session["email"]:
-        return render_template(
-            "pages/digital-justice-user.html",
-            org_selection=session["org_selection"],
-            email=session["email"],
-        )
-    return render_template(
-        "pages/join-selection.html",
-        org_selection=session["org_selection"],
-        email=session["email"],
-    )
+    email = session.get("email", "").lower()
+    org_selection = session.get("org_selection", [])
+
+    template = "pages/digital-justice-user.html" if is_digital_justice_email(email) else "pages/join-selection.html"
+    return render_template(template, org_selection=org_selection, email=email)
+
+
+def is_digital_justice_email(email):
+    return "digital.justice.gov.uk" in email.lower()
 
 
 @main.route("/thank-you")

--- a/join_github_app/templates/pages/digital-justice-user.html
+++ b/join_github_app/templates/pages/digital-justice-user.html
@@ -1,0 +1,48 @@
+{% extends "components/base.html" %}
+
+{% block pageTitle %}
+Using SSO for GitHub Access
+{% endblock %}
+
+{% block beforeContent %}
+{{ govukBackLink ({
+'text': 'Back',
+'href': '/select-organisations'
+}) }}
+{% endblock %}
+
+{% block content %}
+<h1 class="govuk-heading-l">Using Single Sign-On Access</h1>
+
+<p class="govuk-body">
+  Your email address <strong>{{email}}</strong> is registered for SSO access to the GitHub organisation. Single Sign-On
+  (SSO) is a convenient
+  method allowing you to access multiple services with one set of login credentials.
+</p>
+<p class="govuk-body">
+  By clicking the button below for the chosen organisation, you'll be directed to a secure login
+  page.
+</p>
+
+<p class="govuk-body">
+  Enter your @digital.justice.gov.uk credentials there, and you'll be automatically joined to the selected GitHub
+  organisation.
+</p>
+
+{% if 'ministryofjustice' in org_selection %}
+<a href="https://github.com/orgs/ministryofjustice/sso" class="govuk-button" role="button" target="_blank">
+  Join Ministry of Justice
+</a>
+{% endif %}
+
+
+{% if 'analytical-services' in org_selection %}
+<a href="https://sso-link-for-analytical-services" class="govuk-button" role="button" target="_blank">
+  Join MoJ Analytical Services
+</a>
+{% endif %}
+<p class="govuk-body">
+  If you require further assistance, contact us on the Operations Engineering team Slack channel <a
+    href="https://mojdt.slack.com/archives/C01BUKJSZD4" class="govuk-link">#ask-operations-engineering</a>.
+</p>
+{% endblock %}

--- a/join_github_app/templates/pages/digital-justice-user.html
+++ b/join_github_app/templates/pages/digital-justice-user.html
@@ -15,17 +15,17 @@ Using SSO for GitHub Access
 <h1 class="govuk-heading-l">Using Single Sign-On Access</h1>
 
 <p class="govuk-body">
-  Your email address <strong>{{email}}</strong> is registered for SSO access to the GitHub organisation. Single Sign-On
-  (SSO) is a convenient
-  method allowing you to access multiple services with one set of login credentials.
+  Your email address <strong>{{email}}</strong> is registered for Single Sign-On (SSO) access to the GitHub organisations below. SSO
+  is a convenient
+  method that enables access to multiple services with one set of login credentials.
 </p>
 <p class="govuk-body">
-  By clicking the button below for the chosen organisation, you'll be directed to a secure login
+  Click the button below for the chosen organisation to open a secure login
   page.
 </p>
 
 <p class="govuk-body">
-  Enter your @digital.justice.gov.uk credentials there, and you'll be automatically joined to the selected GitHub
+  Enter your @digital.justice.gov.uk credentials there to automatically join the selected GitHub
   organisation.
 </p>
 

--- a/makefile
+++ b/makefile
@@ -26,7 +26,7 @@ format: venv
 test: venv
 	venv/bin/pip3 install pytest
 	venv/bin/pip3 install coverage
-	export FLASK_CONFIGURATION=development; source .env.example; venv/bin/coverage run -m pytest tests/ -v
+	export FLASK_CONFIGURATION=development; venv/bin/coverage run -m pytest tests/ -v
 
 report:
 	venv/bin/coverage html && open htmlcov/index.html

--- a/makefile
+++ b/makefile
@@ -26,7 +26,7 @@ format: venv
 test: venv
 	venv/bin/pip3 install pytest
 	venv/bin/pip3 install coverage
-	export FLASK_CONFIGURATION=development; venv/bin/coverage run -m pytest tests/ -v
+	export FLASK_CONFIGURATION=development; source .env.example; venv/bin/coverage run -m pytest tests/ -v
 
 report:
 	venv/bin/coverage html && open htmlcov/index.html

--- a/tests/views/test_views.py
+++ b/tests/views/test_views.py
@@ -31,7 +31,6 @@ class TestViews(unittest.TestCase):
                 redirect = True
         self.assertEqual(redirect, True)
 
-    @patch.dict(os.environ, {"APP_SECRET_KEY": "abc"})
     def test_join_selection_digital_justice_user(self):
         with self.app.test_client() as client:
             with client.session_transaction() as sess:

--- a/tests/views/test_views.py
+++ b/tests/views/test_views.py
@@ -10,6 +10,7 @@ class TestViews(unittest.TestCase):
     def setUp(self):
         self.github_script = MagicMock(GithubScript)
         self.app = join_github_app.create_app(self.github_script, False)
+        self.app.config['SECRET_KEY'] = 'test_flask'
 
     def test_default(self):
         response = self.app.test_client().get("/")
@@ -30,6 +31,7 @@ class TestViews(unittest.TestCase):
                 redirect = True
         self.assertEqual(redirect, True)
 
+    @patch.dict(os.environ, {"APP_SECRET_KEY": "abc"})
     def test_join_selection_digital_justice_user(self):
         with self.app.test_client() as client:
             with client.session_transaction() as sess:

--- a/tests/views/test_views.py
+++ b/tests/views/test_views.py
@@ -30,6 +30,26 @@ class TestViews(unittest.TestCase):
                 redirect = True
         self.assertEqual(redirect, True)
 
+    def test_join_selection_digital_justice_user(self):
+        with self.app.test_client() as client:
+            with client.session_transaction() as sess:
+                sess['email'] = 'user@digital.justice.gov.uk'
+                sess['org_selection'] = ['ministryofjustice']
+
+            response = client.get("/join-selection")
+            self.assertEqual(response.status_code, 200)
+            self.assertIn('Using Single Sign-On', str(response.data))
+
+    def test_join_selection_other_user(self):
+        with self.app.test_client() as client:
+            with client.session_transaction() as sess:
+                sess['email'] = 'user@example.com'
+                sess['org_selection'] = ['ministryofjustice']
+
+            response = client.get("/join-selection")
+            self.assertEqual(response.status_code, 200)
+            self.assertNotIn('Using Single Sign-On', str(response.data))
+
     def test_thank_you(self):
         response = self.app.test_client().get("/thank-you")
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
👀 Purpose
---

This PR introduces a new template, digital-justice-user.html, and updates the routing logic to render this template under specific conditions. The new template is designed to provide clear instructions to users with a @digital.justice.gov.uk email domain on how to authenticate via Single Sign-On (SSO).

♻️ What's Changed
---

- New Template: Added digital-justice-user.html. This template includes instructions and relevant information for users with a @digital.justice.gov.uk email domain, guiding them through the process of SSO authentication.

- Conditional Rendering in Route: Modified the join_selection view to conditionally render the digital-justice-user.html template when a user's email address contains the @digital.justice.gov.uk domain. The template is rendered with the user's email address and instructions for SSO authentication.

- Template Testing: Updated unit tests to cover the new routing logic, ensuring that the correct template is rendered based on the user's email domain.

📝 Notes
--

This is how the page appears with one org selected:
<img width="1368" alt="image" src="https://github.com/ministryofjustice/operations-engineering-join-github/assets/31217584/a8bcab0c-a60b-41b3-a9dd-8729966f73a1">

And with both orgs selected
<img width="1368" alt="image" src="https://github.com/ministryofjustice/operations-engineering-join-github/assets/31217584/747c3a37-a89a-4abc-8881-6c4c9cbc62ed">
