### PR TITLE
♻️ User Experience Enhancments for Digital Justice Domain in Select Organisations

### DIFF
--- a/join_github_app/main/views.py
+++ b/join_github_app/main/views.py
@@ -57,7 +57,6 @@ def select_organisations():
 
     if request.method == "POST":
         session["org_selection"] = request.form.getlist("organisation_selection")
-        print(session["org_selection"])
         if not session["org_selection"]:
             flash("Please select at least one organisation.")
             return render_template("pages/select-organisations.html",

--- a/join_github_app/main/views.py
+++ b/join_github_app/main/views.py
@@ -53,14 +53,19 @@ def outside_collaborator():
 
 @main.route("/select-organisations", methods=["GET", "POST"])
 def select_organisations():
+    is_digital_justice_user = "digital.justice.gov.uk" in session.get("email", "").lower()
+
     if request.method == "POST":
         session["org_selection"] = request.form.getlist("organisation_selection")
         print(session["org_selection"])
-        if session["org_selection"] == []:
+        if not session["org_selection"]:
             flash("Please select at least one organisation.")
-            return render_template("pages/select-organisations.html")
+            return render_template("pages/select-organisations.html",
+                                   is_digital_justice_user=is_digital_justice_user)
         return redirect("/join-selection")
-    return render_template("pages/select-organisations.html")
+
+    return render_template("pages/select-organisations.html",
+                           is_digital_justice_user=is_digital_justice_user)
 
 
 @main.route("/join-selection")

--- a/join_github_app/templates/pages/digital-justice-user.html
+++ b/join_github_app/templates/pages/digital-justice-user.html
@@ -15,7 +15,9 @@ Using SSO for GitHub Access
 <h1 class="govuk-heading-l">Using Single Sign-On Access</h1>
 
 <p class="govuk-body">
-  Your email address <strong>{{email}}</strong> is registered for Single Sign-On (SSO) access to the GitHub organisations below. SSO
+  Your email address <strong>{{email}}</strong> is registered for Single Sign-On (SSO) access to the "ministryofjustice"
+  GitHub
+  organisations. SSO
   is a convenient
   method that enables access to multiple services with one set of login credentials.
 </p>
@@ -36,11 +38,6 @@ Using SSO for GitHub Access
 {% endif %}
 
 
-{% if 'analytical-services' in org_selection %}
-<a href="https://sso-link-for-analytical-services" class="govuk-button" role="button" target="_blank">
-  Join MoJ Analytical Services
-</a>
-{% endif %}
 <p class="govuk-body">
   If you require further assistance, contact us on the Operations Engineering team Slack channel <a
     href="https://mojdt.slack.com/archives/C01BUKJSZD4" class="govuk-link">#ask-operations-engineering</a>.

--- a/join_github_app/templates/pages/join-github.html
+++ b/join_github_app/templates/pages/join-github.html
@@ -1,42 +1,42 @@
 {% extends "components/base.html" %}
 
 {% block pageTitle %}
-    Joining GitHub
+Joining GitHub
 {% endblock %}
 
 {% block beforeContent %}
-  {{ govukBackLink ({
-    'text': 'Back',
-    'href': '/'
-  }) }}
+{{ govukBackLink ({
+'text': 'Back',
+'href': '/'
+}) }}
 {% endblock %}
 
 {% block content %}
-  {{ super() }}
-    <h1 class="govuk-heading-xl">Joining GitHub</h1>
+{{ super() }}
+<h1 class="govuk-heading-xl">Joining GitHub</h1>
 
-    <p class="govuk-body">
-        The Ministry of Justice maintains two GitHub Organisations,
-    <ul class="govuk-list govuk-list--bullet">
-        <li><a class="govuk-link" href="https://github.com/ministryofjustice">Ministry of Justice</a></li>
-        <li><a class="govuk-link" href="https://github.com/moj-analytical-services">MoJ Analytical Services</a></li>
-    </ul>
-    </p>
+<p class="govuk-body">
+    The Ministry of Justice maintains two GitHub Organisations,
+<ul class="govuk-list govuk-list--bullet">
+    <li><a class="govuk-link" href="https://github.com/ministryofjustice">Ministry of Justice</a></li>
+    <li><a class="govuk-link" href="https://github.com/moj-analytical-services">MoJ Analytical Services</a></li>
+</ul>
+</p>
 
-    <form action="/join-github" method="POST">
-        {{ govukInput({
-            'id': 'email_address', 
-            'name': 'emailAddress', 
-            'classes': 'govuk-!-width-one-third',
-            'label': {'text': 'Please provide the email address you want to join with:'}, 
-        })  }}
-    
-        {{ govukButton({
-            'text': "Next"
-        }) }}
+<form action="/join-github" method="POST">
+    {{ govukInput({
+    'id': 'email_address',
+    'name': 'emailAddress',
+    'classes': 'govuk-!-width-one-third',
+    'label': {'text': 'Please provide the email address you want to join with:'},
+    }) }}
 
-    </form>
+    {{ govukButton({
+    'text': "Next"
+    }) }}
 
-    <br>
+</form>
+
+<br>
 
 {% endblock %}

--- a/join_github_app/templates/pages/select-organisations.html
+++ b/join_github_app/templates/pages/select-organisations.html
@@ -1,54 +1,64 @@
 {% extends "components/base.html" %}
 
 {% block pageTitle %}
-    Select Organisation
+Select Organisation
 {% endblock %}
 
 {% block beforeContent %}
-  {{ govukBackLink ({
-    'text': 'Back',
-    'href': '/join-github'
-  }) }}
+{{ govukBackLink ({
+'text': 'Back',
+'href': '/join-github'
+}) }}
 {% endblock %}
 
 {% block content %}
-  {{ super() }}
-    <form action="/select-organisations" method="POST">
-        {{ govukCheckboxes ({
-            'name': 'organisation_selection',
-            'fieldset': {
-              'legend': {
-                'text': 'Which MoJ GitHub Organisation do you want to join?',
-                'isPageHeading': 'true',
-                'classes': 'govuk-fieldset__legend--l'
-              }
-            },
-            'hint': {
-              'text': 'Select all that apply.'
-            },
-            'items': [
-            {
-              'value': 'ministryofjustice',
-              'text': 'Ministry of Justice'
-            },
-            {
-              'value': 'analytical-services',
-              'text': 'MoJ Analytical Services',
-            }
-            ]
-          }) }}
-    
-        {{ govukButton({
-            'text': 'Next'
-        }) }}
+{{ super() }}
+<form action="/select-organisations" method="POST">
+  {{ govukCheckboxes ({
+  'name': 'organisation_selection',
+  'fieldset': {
+  'legend': {
+  'text': 'Which MoJ GitHub Organisation do you want to join?',
+  'isPageHeading': 'true',
+  'classes': 'govuk-fieldset__legend--l'
+  }
+  },
+  'hint': {
+  'text': 'Select all that apply.'
+  },
+  'items': [
+  {
+  'value': 'ministryofjustice',
+  'text': 'Ministry of Justice'
+  },
+  {
+  'value': 'analytical-services',
+  'text': 'MoJ Analytical Services',
+  'disabled': is_digital_justice_user,
+  'error': 'error',
+  }
+  ]
+  }) }}
 
-    </form>
+  {{ govukButton({
+  'text': 'Next'
+  }) }}
 
+</form>
 
+{% if is_digital_justice_user %}
+<div class="govuk-inset-text">
+  <p class="govuk-body">
+    <strong>Note:</strong> The "MoJ Analytical Services" option is not available for @digital.justice.gov.uk email
+    addresses.
+    If you wish to access this organisation, you should start the process again with an "@justice.gov.uk" email address.
+  </p>
+</div>
+{% endif %}
 
-    <p class="govuk-body">
-        If you require further assistance contact us on the Operations Engineering team Slack channel <a
-            href="https://mojdt.slack.com/archives/C01BUKJSZD4" class="govuk-link">#ask-operations-engineering</a>.
-    </p>
+<p class="govuk-body">
+  If you require further assistance contact us on the Operations Engineering team Slack channel <a
+    href="https://mojdt.slack.com/archives/C01BUKJSZD4" class="govuk-link">#ask-operations-engineering</a>.
+</p>
 
 {% endblock %}

--- a/tests/views/test_views.py
+++ b/tests/views/test_views.py
@@ -51,6 +51,24 @@ class TestViews(unittest.TestCase):
             self.assertEqual(response.status_code, 200)
             self.assertNotIn('Using Single Sign-On', str(response.data))
 
+    def test_select_organisations_digital_justice_user(self):
+        with self.app.test_client() as client:
+            with client.session_transaction() as sess:
+                sess['email'] = 'user@digital.justice.gov.uk'
+            response = client.get("/select-organisations")
+            self.assertEqual(response.status_code, 200)
+            self.assertIn('MoJ Analytical Services', str(response.data))
+            self.assertIn('disabled', str(response.data))  # Check if the checkbox is disabled
+
+    def test_select_organisations_other_user(self):
+        with self.app.test_client() as client:
+            with client.session_transaction() as sess:
+                sess['email'] = 'user@example.com'
+            response = client.get("/select-organisations")
+            self.assertEqual(response.status_code, 200)
+            self.assertIn('MoJ Analytical Services', str(response.data))
+            self.assertNotIn('disabled', str(response.data))  # Check if the checkbox is not disabled
+
     def test_thank_you(self):
         response = self.app.test_client().get("/thank-you")
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## 👀 Purpose

- This pull request introduces several updates to improve how our application handles users with a @digital.justice.gov.uk email domain in the select-organisations feature.

## ♻️ What's changed

- :technologist: Digital Justice Domain Logic: Implemented logic to identify users with a @digital.justice.gov.uk email domain and pass this information to subsequent processes.

- :fire: Code Clean-up: Removed an unnecessary print statement that was used for debugging.

- :white_check_mark: Testing Digital User Logic: Added unit tests to validate the new logic for handling @digital.justice.gov.uk users in the select-organisations route.

- :fire: Restriction for Digital Users: Removed the ability for users with a @digital.justice.gov.uk email to access the MoJ Analytical Services organisation.

- :children_crossing: UI Enhancement for Digital Users: Disabled the option for digital users to select the MoJ Analytical Services organisation, preventing ineligible selections.

- :art: HTML Formatting: Formatted all modified HTML files using js-beautify (default VS Code settings) for better readability and maintainability.

## 📝 Notes

- Testing has been conducted to confirm the functionality of the new features.