### PR TITLE
✨ Add `PRE_COMMAND` to megalinter to install python dependencies before running linter

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -37,6 +37,7 @@ MARKDOWN_MARKDOWN_LINK_CHECK_ARGUMENTS: "-q"
 PRE_COMMANDS: 
   - command: pip install -r requirements.txt
     cwd: workspace
+    venv: pylint
 
 PLUGINS:
   - https://raw.githubusercontent.com/shiranr/linkcheck/v2.0.17.beta/mega-linter-plugin-linkcheck/linkcheck.megalinter-descriptor.yml

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -35,7 +35,7 @@ VALIDATE_ALL_CODEBASE: false
 LOG_LEVEL: INFO
 MARKDOWN_MARKDOWN_LINK_CHECK_ARGUMENTS: "-q"
 PRE_COMMANDS: 
-  - command: pip install -r requirements.txt"
+  - command: pip install -r requirements.txt
     cwd: workspace
 
 PLUGINS:

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -34,6 +34,9 @@ GITHUB_COMMENT_REPORTER: true
 VALIDATE_ALL_CODEBASE: false
 LOG_LEVEL: INFO
 MARKDOWN_MARKDOWN_LINK_CHECK_ARGUMENTS: "-q"
+PRE_COMMANDS: 
+  - command: pip install -r requirements.txt"
+    cwd: workspace
 
 PLUGINS:
   - https://raw.githubusercontent.com/shiranr/linkcheck/v2.0.17.beta/mega-linter-plugin-linkcheck/linkcheck.megalinter-descriptor.yml

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -34,21 +34,10 @@ GITHUB_COMMENT_REPORTER: true
 VALIDATE_ALL_CODEBASE: false
 LOG_LEVEL: INFO
 MARKDOWN_MARKDOWN_LINK_CHECK_ARGUMENTS: "-q"
+
 PRE_COMMANDS: 
   - command: pip install -r /github/workspace/requirements.txt
     venv: pylint
-
-  - command: cwd
-    venv: pylint
-
-  - command: ls
-    venv: pylint
-
-  - command: cwd
-    cwd: workspace
-
-  - command: ls
-    cwd: workspace
 
 PLUGINS:
   - https://raw.githubusercontent.com/shiranr/linkcheck/v2.0.17.beta/mega-linter-plugin-linkcheck/linkcheck.megalinter-descriptor.yml

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -35,9 +35,20 @@ VALIDATE_ALL_CODEBASE: false
 LOG_LEVEL: INFO
 MARKDOWN_MARKDOWN_LINK_CHECK_ARGUMENTS: "-q"
 PRE_COMMANDS: 
-  - command: pip install -r requirements.txt
-    cwd: workspace
+  - command: pip install -r /github/workspace/requirements.txt
     venv: pylint
+
+  - command: cwd
+    venv: pylint
+
+  - command: ls
+    venv: pylint
+
+  - command: cwd
+    cwd: workspace
+
+  - command: ls
+    cwd: workspace
 
 PLUGINS:
   - https://raw.githubusercontent.com/shiranr/linkcheck/v2.0.17.beta/mega-linter-plugin-linkcheck/linkcheck.megalinter-descriptor.yml

--- a/tests/views/test_views.py
+++ b/tests/views/test_views.py
@@ -13,9 +13,6 @@ class TestViews(unittest.TestCase):
         self.app = join_github_app.create_app(self.github_script, False)
         self.app.config["SECRET_KEY"] = "test_flask"
 
-    def dummy_python_change_to_test_linter(self):
-        self.assertEqual(True, True)
-
     def test_default(self):
         response = self.app.test_client().get("/")
         self.assertEqual(response.status_code, 200)

--- a/tests/views/test_views.py
+++ b/tests/views/test_views.py
@@ -13,6 +13,9 @@ class TestViews(unittest.TestCase):
         self.app = join_github_app.create_app(self.github_script, False)
         self.app.config["SECRET_KEY"] = "test_flask"
 
+    def dummy_python_change_to_test_linter(self):
+        self.assertEqual(True, True)
+
     def test_default(self):
         response = self.app.test_client().get("/")
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## 👀 Purpose

- To remove false positives of pylint errors
- To enable pylint to check whether a module import is possible

## ♻️ What's changed

- Add a [precommand](https://megalinter.io/latest/configuration/#pre-commands) to install dependencies in the pylint virtual environment before lining is run

## 📝 Notes

- Megalinter uses a different virtual environment per linter (which is nice isolation 📦 ) - but it does mean that we need to manually install dependencies before the linters run (if they require the dependencies to be installed to run)
- The command used is a bit odd `pip install -r /github/workspace/requirements.txt`- essentially the working directory is the pylint virtual env, and `/github/workspace` is the root of our source code, where we need to go to get the requirements file