### PR TITLE
👷 Ignore that doctype isn't declared first

### DIFF
--- a/.htmlhintrc
+++ b/.htmlhintrc
@@ -1,0 +1,3 @@
+{
+  "doctype-first": false, // Doctype must be declared first.
+}


### PR DESCRIPTION
We use flask, which often means something else is declared in a template.