### PR TITLE
Selectable GitHub Organisations for Production and Development Environments

### DIFF
--- a/join_github_app/config/development.py
+++ b/join_github_app/config/development.py
@@ -11,3 +11,6 @@ AUTH0_CLIENT_ID = environ.get("AUTH0_CLIENT_ID")
 AUTH0_CLIENT_SECRET = environ.get("AUTH0_CLIENT_SECRET")
 AUTH0_DOMAIN = environ.get("AUTH0_DOMAIN")
 APP_SECRET_KEY = environ.get("APP_SECRET_KEY")
+SELECTABLE_ORGANISATIONS = [
+    {'value': 'moj-test', 'text': 'Ministry of Justice Test Organisation'}
+]

--- a/join_github_app/config/production.py
+++ b/join_github_app/config/production.py
@@ -11,3 +11,7 @@ AUTH0_CLIENT_ID = environ.get("AUTH0_CLIENT_ID")
 AUTH0_CLIENT_SECRET = environ.get("AUTH0_CLIENT_SECRET")
 AUTH0_DOMAIN = environ.get("AUTH0_DOMAIN")
 APP_SECRET_KEY = environ.get("APP_SECRET_KEY")
+SELECTABLE_ORGANISATIONS = [
+    {'value': 'ministryofjustice', 'text': 'Ministry of Justice'},
+    {'value': 'analytical-services', 'text': 'MoJ Analytical Services'}
+]

--- a/join_github_app/config/test.py
+++ b/join_github_app/config/test.py
@@ -1,4 +1,4 @@
-""" Config values to be used during development """
+""" Config values to be used during testing """
 from os import environ
 
 DEBUG = True

--- a/join_github_app/config/test.py
+++ b/join_github_app/config/test.py
@@ -1,0 +1,17 @@
+""" Config values to be used during development """
+from os import environ
+
+DEBUG = True
+FLASK_DEBUG = True
+MAIL_FROM_EMAIL = "operations-engineering@digital.justice.gov.uk"
+PORT = 4567
+SSL_REDIRECT = False
+TESTING = True
+AUTH0_CLIENT_ID = environ.get("AUTH0_CLIENT_ID")
+AUTH0_CLIENT_SECRET = environ.get("AUTH0_CLIENT_SECRET")
+AUTH0_DOMAIN = environ.get("AUTH0_DOMAIN")
+APP_SECRET_KEY = environ.get("APP_SECRET_KEY")
+SELECTABLE_ORGANISATIONS = [
+    {'value': 'ministryofjustice', 'text': 'Ministry of Justice'},
+    {'value': 'analytical-services', 'text': 'MoJ Analytical Services'}
+]

--- a/join_github_app/main/views.py
+++ b/join_github_app/main/views.py
@@ -62,9 +62,17 @@ def select_organisations():
             return render_template("pages/select-organisations.html",
                                    is_digital_justice_user=is_digital_justice_user)
         return redirect("/join-selection")
+    
+    selectable_orgs = current_app.config['SELECTABLE_ORGANISATIONS']
+    checkboxes_items = []
+    for org in selectable_orgs:
+        item = {'value': org['value'], 'text': org['text']}
+        if org['value'] == 'analytical-services' and is_digital_justice_user:
+            item['is_digital_justice_user'] = is_digital_justice_user
+        checkboxes_items.append(item)
 
     return render_template("pages/select-organisations.html",
-                           is_digital_justice_user=is_digital_justice_user)
+                           checkboxes_items=checkboxes_items)
 
 
 @main.route("/join-selection")

--- a/join_github_app/main/views.py
+++ b/join_github_app/main/views.py
@@ -68,7 +68,7 @@ def select_organisations():
     for org in selectable_orgs:
         item = {'value': org['value'], 'text': org['text']}
         if org['value'] == 'analytical-services' and is_digital_justice_user:
-            item['is_digital_justice_user'] = is_digital_justice_user
+            item['disabled'] = is_digital_justice_user
         checkboxes_items.append(item)
 
     return render_template("pages/select-organisations.html",

--- a/join_github_app/main/views.py
+++ b/join_github_app/main/views.py
@@ -72,7 +72,7 @@ def select_organisations():
         checkboxes_items.append(item)
 
     return render_template("pages/select-organisations.html",
-                           checkboxes_items=checkboxes_items)
+                           checkboxes_items=checkboxes_items, is_digital_justice_user=is_digital_justice_user)
 
 
 @main.route("/join-selection")

--- a/join_github_app/templates/pages/digital-justice-user.html
+++ b/join_github_app/templates/pages/digital-justice-user.html
@@ -37,6 +37,11 @@ Using SSO for GitHub Access
 </a>
 {% endif %}
 
+{% if 'moj-test' in org_selection %}
+<a href="https://link/to/mojtestorg/sso" class="govuk-button" role="button" target="_blank">
+  Join Ministry of Justice Test Organisation
+</a>
+{% endif %}
 
 <p class="govuk-body">
   If you require further assistance, contact us on the Operations Engineering team Slack channel <a

--- a/join_github_app/templates/pages/select-organisations.html
+++ b/join_github_app/templates/pages/select-organisations.html
@@ -1,64 +1,40 @@
 {% extends "components/base.html" %}
 
 {% block pageTitle %}
-Select Organisation
+    Select Organisation
 {% endblock %}
 
 {% block beforeContent %}
-{{ govukBackLink ({
-'text': 'Back',
-'href': '/join-github'
-}) }}
+    {{ govukBackLink({
+        'text': 'Back',
+        'href': '/join-github'
+    }) }}
 {% endblock %}
 
 {% block content %}
-{{ super() }}
-<form action="/select-organisations" method="POST">
-  {{ govukCheckboxes ({
-  'name': 'organisation_selection',
-  'fieldset': {
-  'legend': {
-  'text': 'Which MoJ GitHub Organisation do you want to join?',
-  'isPageHeading': 'true',
-  'classes': 'govuk-fieldset__legend--l'
-  }
-  },
-  'hint': {
-  'text': 'Select all that apply.'
-  },
-  'items': [
-  {
-  'value': 'ministryofjustice',
-  'text': 'Ministry of Justice'
-  },
-  {
-  'value': 'analytical-services',
-  'text': 'MoJ Analytical Services',
-  'disabled': is_digital_justice_user,
-  'error': 'error',
-  }
-  ]
-  }) }}
-
-  {{ govukButton({
-  'text': 'Next'
-  }) }}
-
-</form>
-
-{% if is_digital_justice_user %}
-<div class="govuk-inset-text">
-  <p class="govuk-body">
-    <strong>Note:</strong> The "MoJ Analytical Services" option is not available for @digital.justice.gov.uk email
-    addresses.
-    If you wish to access this organisation, you should start the process again with an "@justice.gov.uk" email address.
-  </p>
-</div>
-{% endif %}
-
-<p class="govuk-body">
-  If you require further assistance contact us on the Operations Engineering team Slack channel <a
-    href="https://mojdt.slack.com/archives/C01BUKJSZD4" class="govuk-link">#ask-operations-engineering</a>.
-</p>
-
+    {{ super() }}
+    <form action="/select-organisations" method="POST">
+      {{ govukCheckboxes({
+        'name': 'organisation_selection',
+        'fieldset': {
+            'legend': {
+                'text': 'Which MoJ GitHub Organisation do you want to join?',
+                'isPageHeading': 'true',
+                'classes': 'govuk-fieldset__legend--l'
+            }
+        },
+        'hint': {
+            'text': 'Select all that apply.'
+        },
+        'items': checkboxes_items
+      }) }}
+      
+      {{ govukButton({
+          'text': 'Next'
+      }) }}
+    </form>
+    <p class="govuk-body">
+        If you require further assistance contact us on the Operations Engineering team Slack channel 
+        <a href="https://mojdt.slack.com/archives/C01BUKJSZD4" class="govuk-link">#ask-operations-engineering</a>.
+    </p>
 {% endblock %}

--- a/join_github_app/templates/pages/select-organisations.html
+++ b/join_github_app/templates/pages/select-organisations.html
@@ -33,6 +33,17 @@
           'text': 'Next'
       }) }}
     </form>
+
+    {% if is_digital_justice_user %}
+      <div class="govuk-inset-text">
+        <p class="govuk-body">
+          <strong>Note:</strong> The "MoJ Analytical Services" option is not available for @digital.justice.gov.uk email
+          addresses.
+          If you wish to access this organisation, you should start the process again with an "@justice.gov.uk" email address.
+        </p>
+      </div>
+    {% endif %}
+
     <p class="govuk-body">
         If you require further assistance contact us on the Operations Engineering team Slack channel 
         <a href="https://mojdt.slack.com/archives/C01BUKJSZD4" class="govuk-link">#ask-operations-engineering</a>.

--- a/makefile
+++ b/makefile
@@ -26,7 +26,7 @@ format: venv
 test: venv
 	venv/bin/pip3 install pytest
 	venv/bin/pip3 install coverage
-	export FLASK_CONFIGURATION=development; venv/bin/coverage run -m pytest tests/ -v
+	export FLASK_CONFIGURATION=test; venv/bin/coverage run -m pytest tests/ -v
 
 report:
 	venv/bin/coverage html && open htmlcov/index.html


### PR DESCRIPTION
As the title says, we now only display options for the MoJ AS org and the regular MoJ org if we're in the production environment. Otherwise, it'll show the test organisation.