### PR TITLE
:memo: Change wording on the GitHub justice user path

### DIFF
--- a/join_github_app/templates/pages/justice-user.html
+++ b/join_github_app/templates/pages/justice-user.html
@@ -1,7 +1,7 @@
 {% extends "components/base.html" %}
 
 {% block pageTitle %}
-GitHub Access via Azure AD
+GitHub Access Invitation
 {% endblock %}
 
 {% block beforeContent %}
@@ -12,30 +12,31 @@ GitHub Access via Azure AD
 {% endblock %}
 
 {% block content %}
-<h1 class="govuk-heading-l">GitHub Access via Azure Active Directory (AD)</h1>
+<h1 class="govuk-heading-l">GitHub Organisation Invitation</h1>
 
 <p class="govuk-body">
-  Your email address <strong>{{email}}</strong> is registered for access to the Ministry of Justice GitHub organisations
-  via Azure
-  Active Directory (AD). Azure AD is a secure and convenient method that allows you to use your @justice.gov.uk
-  credentials to access multiple services.
-</p>
-<p class="govuk-body">
-  After clicking the button below, you will be directed to a secure Azure AD login page.
+  To access the Ministry of Justice GitHub organisations you've selected, your email address <strong>{{email}}</strong>
+  will be verified
+  using Azure Active Directory (AD). This secure step is essential to confirm your identity and initiate the process of
+  joining our GitHub organisations.
 </p>
 
 <p class="govuk-body">
-  Once you enter your @justice.gov.uk credentials, you will automatically be added to the selected GitHub
-  organisation.
+  By clicking the button below, you will be redirected to a secure Azure AD login page for authentication.
 </p>
-{% for org in org_selection %}
+
+<p class="govuk-body">
+  After successfully authenticating with your @justice.gov.uk credentials, GitHub will send an invitation to
+  <strong>{{email}}</strong>. You will need to accept this invitation to join the selected GitHub organisation.
+</p>
+
 <form action="/login" method="get">
-  <button type="submit" class="govuk-button">Authenticate to {{ org | capitalize }}</button>
+  <button type="submit" class="govuk-button">Authenticate {{ email }}</button>
 </form>
-{% endfor %}
 
 <p class="govuk-body">
-  If you require further assistance, contact us on the Operations Engineering team Slack channel <a
-    href="https://mojdt.slack.com/archives/C01BUKJSZD4" class="govuk-link">#ask-operations-engineering</a>.
+  If you require further assistance or have any questions, feel free to contact our Operations Engineering team via the
+  Slack channel <a href="https://mojdt.slack.com/archives/C01BUKJSZD4"
+    class="govuk-link">#ask-operations-engineering</a>.
 </p>
 {% endblock %}


### PR DESCRIPTION
## 👀 Purpose

- This PR aims to clarify the steps involved in the authentication and invitation process, ensuring users understand that Azure AD authentication is a preliminary step before receiving an invitation to join the desired GitHub organisation.

## ♻️ What's changed

- Revised the justice-user.html template to provide clear and accurate instructions about the Azure AD authentication process and subsequent steps.

- Introduced a more descriptive title - "Authenticate with Azure AD for GitHub Organization Invitation" - to immediately inform users about the process.

- Refined the language used in the template to make it more user-friendly and to accurately convey that Azure AD authentication is for identity verification and does not directly grant access to GitHub organizations.

## 📝 Notes

-