### PR TITLE
:recycle: Replace all mentions of GH_TOKEN

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-export GH_TOKEN=fake
+export ADMIN_GITHUB_TOKEN=fake
 export AUTH0_CLIENT_ID=dev
 export AUTH0_CLIENT_SECRET=dev
 export AUTH0_DOMAIN=operations-engineering.eu.auth0.com

--- a/deployments/templates/deployment.yml
+++ b/deployments/templates/deployment.yml
@@ -20,7 +20,7 @@ spec:
           ports:
             - containerPort: 4567
           env:
-            - name: GH_TOKEN
+            - name: ADMIN_GITHUB_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: join-github-token

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
       FLASK_CONFIGURATION: "development"
       FLASK_DEBUG: "true"
       FLASK_APP: "operations_engineering_join_github"
-      GH_TOKEN: "dummy"
+      ADMIN_GITHUB_TOKEN: "dummy"
       AUTH0_CLIENT_ID: "dev"
       AUTH0_CLIENT_SECRET: "dev"
       AUTH0_DOMAIN: "operations-engineering.eu.auth0.com"

--- a/operations_engineering_join_github.py
+++ b/operations_engineering_join_github.py
@@ -9,10 +9,10 @@ from join_github_app import create_app
 
 
 def get_tokens():
-    github_token = environ.get("GH_TOKEN")
+    github_token = environ.get("ADMIN_GITHUB_TOKEN")
     if not github_token:
         # Look for a local .env file
-        github_token = dotenv_values(".env").get("GH_TOKEN")
+        github_token = dotenv_values(".env").get("ADMIN_GITHUB_TOKEN")
         if not github_token:
             logging.error("Failed to find a GitHub Token")
             sys.exit(1)


### PR DESCRIPTION
GH_TOKEN is used when authenticating with the gh cli. To remove this clash I've renamed the environment variable we use to populate GitHub admin keys.
