### PR TITLE
:bug: Fix secret name

### DIFF
--- a/.github/workflows/cicd-deploy-to-dev.yml
+++ b/.github/workflows/cicd-deploy-to-dev.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [main]
 env:
-  KUBE_CLUSTER: ${{ secrets.DEV_KUBE_CLUSTER }}
+  KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
   KUBE_NAMESPACE: ${{ secrets.DEV_KUBE_NAMESPACE }}
   KUBE_CERT: ${{ secrets.DEV_KUBE_CERT }}
   KUBE_TOKEN: ${{ secrets.DEV_KUBE_TOKEN }}


### PR DESCRIPTION
There is no DEV_KUBE_CLUSTER

This PR fixes the error defined here:
https://github.com/ministryofjustice/operations-engineering-join-github/actions/runs/7558609516/job/20580565981