### PR TITLE
🚀  Deploy to Production Pipeline

### DIFF
--- a/.github/workflows/cicd-deploy-to-prod.yml
+++ b/.github/workflows/cicd-deploy-to-prod.yml
@@ -1,0 +1,81 @@
+name: "♻️ Deploy to Production Namespace"
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+env:
+  KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
+  KUBE_NAMESPACE: ${{ secrets.PROD_KUBE_NAMESPACE }}
+  KUBE_CERT: ${{ secrets.PROD_KUBE_CERT }}
+  KUBE_TOKEN: ${{ secrets.PROD_KUBE_TOKEN }}
+
+  IMAGE_TAG: ${{ github.sha }}
+  ECR_REGISTRY: ${{ vars.PROD_ECR_REGISTRY }}
+  ECR_REPOSITORY: ${{ vars.PROD_ECR_REPOSITORY }}
+
+  FLASK_APP_SECRET: ${{ secrets.PROD_FLASK_APP_SECRET }}
+  FLASK_CONFIGURATION: "production"
+
+  AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
+  AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_CLIENT_SECRET }}
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.PROD_ECR_ROLE_TO_ASSUME }}
+          aws-region: ${{ vars.PROD_ECR_REGION }}
+
+      - uses: aws-actions/amazon-ecr-login@v2
+        id: login-ecr
+      - run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+
+  deploy-to-prod:
+    needs: build-push
+    runs-on: ubuntu-latest
+    container: alpine/k8s:1.23.17
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to the cluster
+        run: |
+          echo "${KUBE_CERT}" > ca.crt
+          kubectl config set-cluster ${KUBE_CLUSTER} --certificate-authority=./ca.crt --server=https://${KUBE_CLUSTER}
+          kubectl config set-credentials deploy-user --token=${KUBE_TOKEN}
+          kubectl config set-context ${KUBE_CLUSTER} --cluster=${KUBE_CLUSTER} --user=deploy-user --namespace=${KUBE_NAMESPACE}
+          kubectl config get-contexts
+          kubectl config use-context ${KUBE_CLUSTER}
+
+      - name: Deploy helm chart to operations-engineering-join-github-prod
+        run: |
+          helm upgrade join-github \
+            helm/join-github \
+            --install \
+            --force \
+            --wait \
+            --timeout 10m \
+            --namespace ${KUBE_NAMESPACE} \
+            --set image.tag=${IMAGE_TAG} \
+            --set application.auth0ClientId=${AUTH0_CLIENT_ID} \
+            --set application.auth0ClientSecret=${AUTH0_CLIENT_SECRET} \
+            --set application.appSecretKey=${FLASK_APP_SECRET} \
+            --set application.environment=${FLASK_CONFIGURATION} \
+            --set image.repository=${ECR_REGISTRY}/${ECR_REPOSITORY} \
+            --set ingress.hosts={join-github-prod.cloud-platform.service.justice.gov.uk}

--- a/.github/workflows/cicd-deploy-to-prod.yml
+++ b/.github/workflows/cicd-deploy-to-prod.yml
@@ -11,10 +11,11 @@ env:
   KUBE_CERT: ${{ secrets.PROD_KUBE_CERT }}
   KUBE_TOKEN: ${{ secrets.PROD_KUBE_TOKEN }}
 
-  IMAGE_TAG: ${{ github.sha }}
+  IMAGE_TAG: ${{ github.ref_name }}
   ECR_REGISTRY: ${{ vars.PROD_ECR_REGISTRY }}
   ECR_REPOSITORY: ${{ vars.PROD_ECR_REPOSITORY }}
 
+  ADMIN_GITHUB_TOKEN: ${{ secrets.PROD_ADMIN_GITHUB_TOKEN }}
   FLASK_APP_SECRET: ${{ secrets.PROD_FLASK_APP_SECRET }}
   FLASK_CONFIGURATION: "production"
 
@@ -68,14 +69,16 @@ jobs:
           helm upgrade join-github \
             helm/join-github \
             --install \
+            --atomic \
             --force \
             --wait \
-            --timeout 10m \
             --namespace ${KUBE_NAMESPACE} \
+            --set replicaCount=3 \
             --set image.tag=${IMAGE_TAG} \
             --set application.auth0ClientId=${AUTH0_CLIENT_ID} \
             --set application.auth0ClientSecret=${AUTH0_CLIENT_SECRET} \
             --set application.appSecretKey=${FLASK_APP_SECRET} \
+            --set application.githubToken=${ADMIN_GITHUB_TOKEN} \
             --set application.environment=${FLASK_CONFIGURATION} \
             --set image.repository=${ECR_REGISTRY}/${ECR_REPOSITORY} \
-            --set ingress.hosts={join-github-prod.cloud-platform.service.justice.gov.uk}
+            --set ingress.hosts={prod.join-github.cloud-platform.service.justice.gov.uk}


### PR DESCRIPTION
## 👀 Purpose

- This PR connects to https://github.com/orgs/ministryofjustice/projects/52/views/4?pane=issue&itemId=47594256 and relates to the addition of a new continuous integration/delivery pipeline that will build, push and deploy an image after a new git tag has been pushed to main.

## ♻️ What's changed

- A new file called cicd-deploy-to-prod.yml exists in .github/workflows. This file will trigger on a new tag in the format of `vn.n.n`, which then builds a docker image and pushes it to ECR ready for deployment. It will then upgrade the helm chart in `operations-engineering-join-github-prod` with the new image.

## 📝 Notes

- The image tag name corresponds to the git tag that triggers the pipeline.