### PR TITLE
:fire: Remove the deploy makefile command

### DIFF
--- a/makefile
+++ b/makefile
@@ -56,22 +56,6 @@ local: venv
 docker-up:
 	docker-compose -f docker-compose.yaml up -d
 
-# To run locally, you need to pass the following:
-# make deploy-dev IMAGE=my-image RELEASE_NAME=my-release AUTH0_CLIENT_ID=my-auth0-id AUTH0_CLIENT_SECRET=my-secret APP_SECRET_KEY=my-app-secret HOST_NAME=my-host
-deploy-dev:
-	helm --debug upgrade join-github helm/join-github \
-		--install \
-		--force \
-		--wait \
-		--set image.tag=$(IMAGE) \
-		--set application.auth0ClientId=$(AUTH0_CLIENT_ID) \
-		--set application.auth0ClientSecret=$(AUTH0_CLIENT_SECRET) \
-		--set application.appSecretKey=$(APP_SECRET_KEY) \
-		--set application.apiKey=$(API_KEY) \
-		--set ingress.hosts={$(HOST_NAME).cloud-platform.service.justice.gov.uk} \
-		--set image.repository=754256621582.dkr.ecr.eu-west-2.amazonaws.com/operations-engineering/operations-engineering-join-github-dev-ecr \
-		--namespace operations-engineering-join-github-dev
-
 all:
 
 .PHONY: venv lint test format local clean-test report all


### PR DESCRIPTION
If authenticated users want to deploy to dev, they can use the workflow dispatch.