### PR TITLE
🪲 Add `{{ super() }}` to include base content

### DIFF
--- a/join_github_app/templates/pages/digital-justice-user.html
+++ b/join_github_app/templates/pages/digital-justice-user.html
@@ -5,6 +5,7 @@ Using SSO for GitHub Access
 {% endblock %}
 
 {% block beforeContent %}
+{{ super() }}
 {{ govukBackLink ({
 'text': 'Back',
 'href': '/select-organisations'

--- a/join_github_app/templates/pages/join-github.html
+++ b/join_github_app/templates/pages/join-github.html
@@ -5,6 +5,7 @@ Joining GitHub
 {% endblock %}
 
 {% block beforeContent %}
+{{ super() }}
 {{ govukBackLink ({
 'text': 'Back',
 'href': '/'

--- a/join_github_app/templates/pages/join-selection.html
+++ b/join_github_app/templates/pages/join-selection.html
@@ -5,6 +5,7 @@ Join Selected Orgs
 {% endblock %}
 
 {% block beforeContent %}
+{{ super() }}
 {{ govukBackLink ({
 'text': 'Back',
 'href': '/select-organisations'

--- a/join_github_app/templates/pages/justice-user.html
+++ b/join_github_app/templates/pages/justice-user.html
@@ -5,6 +5,7 @@ GitHub Access Invitation
 {% endblock %}
 
 {% block beforeContent %}
+{{ super() }}
 {{ govukBackLink ({
 'text': 'Back',
 'href': '/select-organisations'

--- a/join_github_app/templates/pages/outside-collaborator.html
+++ b/join_github_app/templates/pages/outside-collaborator.html
@@ -5,6 +5,7 @@ Access for Outside Collaborators
 {% endblock %}
 
 {% block beforeContent %}
+{{ super() }}
   {{ govukBackLink ({
     'text': 'Back',
     'href': '/join-github'

--- a/join_github_app/templates/pages/select-organisations.html
+++ b/join_github_app/templates/pages/select-organisations.html
@@ -5,6 +5,7 @@
 {% endblock %}
 
 {% block beforeContent %}
+{{ super() }}
     {{ govukBackLink({
         'text': 'Back',
         'href': '/join-github'


### PR DESCRIPTION
This PR ensures the phase banner appears on every page. Phase banner sits in the `block beforeContent` which in some pages contains the `govukBackLink`. `{{ super() }}` ensures the base `block beforeContent` is included and not overwritten by the subsequent page `block beforeContent`.