### PR TITLE
🐞 Fix tests that test nothing

### DIFF
--- a/tests/routes/test_auth.py
+++ b/tests/routes/test_auth.py
@@ -104,6 +104,7 @@ class TestViews(unittest.TestCase):
 
     def test_user_has_approved_auth0_email_address(self):
         self.assertFalse(_user_has_approved_auth0_email_address("email@example.com"))
+        self.assertTrue(_user_has_approved_auth0_email_address("email@digital.justice.gov.uk"))
         self.assertTrue(_user_has_approved_auth0_email_address("email@justice.gov.uk"))
         self.assertTrue(_user_has_approved_auth0_email_address("email@cica.gov.uk"))
         self.assertTrue(_user_has_approved_auth0_email_address("email@yjb.gov.uk"))

--- a/tests/services/test_github_service.py
+++ b/tests/services/test_github_service.py
@@ -169,41 +169,38 @@ class TestGithubServiceOrganisationManagement(unittest.TestCase):
 
 
 @patch("github.Github.__new__")
-@patch("join_github_app.main.services.github_service.GithubService.get_user")
-class TestGithubServiceUserManagementIncorrectInputs(unittest.TestCase):
+@patch("join_github_app.main.services.github_service.GithubService.invite_user_to_org_using_email_address")
+class TestGithubServiceUserManagementInvalidInputs(unittest.TestCase):
 
     def setUp(self):
         self.test_email_address = "some-email"
-        self.approved_email_address = "some@justice.gov.uk"
+        self.test_org = "some-org"
 
-    def test_add_new_user_to_github_org_with_incorrect_inputs(self, mock_get_user, mock_github_client_rest_api):
+    def test_add_new_user_to_github_org_with_invalid_inputs(
+            self, mock_invite_user_to_org_using_email_address, mock_github_client_rest_api
+    ):
         github_service = GithubService("")
         github_service.github_client_rest_api = mock_github_client_rest_api
 
-        github_service.add_new_user_to_github_org(None, [], True)
-        mock_get_user.assert_not_called()
+        github_service.add_new_user_to_github_org("", [MINISTRY_OF_JUSTICE], True)
+        mock_invite_user_to_org_using_email_address.assert_not_called()
 
-        github_service.add_new_user_to_github_org("", [], True)
-        mock_get_user.assert_not_called()
+        github_service.add_new_user_to_github_org("", [self.test_org], True)
+        mock_invite_user_to_org_using_email_address.assert_not_called()
+
+        github_service.add_new_user_to_github_org(None, [MINISTRY_OF_JUSTICE], True)
+        mock_invite_user_to_org_using_email_address.assert_not_called()
+
+        github_service.add_new_user_to_github_org(None, [self.test_org], True)
+        mock_invite_user_to_org_using_email_address.assert_not_called()
 
         github_service.add_new_user_to_github_org(self.test_email_address, [], True)
-        mock_get_user.assert_not_called()
+        mock_invite_user_to_org_using_email_address.assert_not_called()
 
         github_service.add_new_user_to_github_org(
-            self.test_email_address, [MOJ_TEST_ORG], True
+            self.test_email_address, [self.test_org], True
         )
-        mock_get_user.assert_not_called()
-
-        github_service.add_new_user_to_github_org("", [MOJ_TEST_ORG], True)
-        mock_get_user.assert_not_called()
-
-        github_service.add_new_user_to_github_org(None, [MOJ_TEST_ORG], True)
-        mock_get_user.assert_not_called()
-
-        github_service.add_new_user_to_github_org(
-            self.test_email_address, [MOJ_TEST_ORG], True
-        )
-        mock_get_user.assert_not_called()
+        mock_invite_user_to_org_using_email_address.assert_not_called()
 
 
 @patch("github.Github.__new__")
@@ -212,7 +209,6 @@ class TestGithubServiceUserManagementValidInputs(unittest.TestCase):
 
     def setUp(self):
         self.test_email_address = "some-email"
-        self.approved_email_address = "some@justice.gov.uk"
 
     def test_add_new_user_to_github_org_send_email_invites_true(
         self, mock_invite_user_to_org_using_email_address, mock_github_client_rest_api
@@ -221,7 +217,7 @@ class TestGithubServiceUserManagementValidInputs(unittest.TestCase):
         github_service.github_client_rest_api = mock_github_client_rest_api
 
         github_service.add_new_user_to_github_org(
-            self.approved_email_address, [MINISTRY_OF_JUSTICE], True
+            self.test_email_address, [MINISTRY_OF_JUSTICE], True
         )
         mock_invite_user_to_org_using_email_address.assert_called()
 
@@ -232,7 +228,7 @@ class TestGithubServiceUserManagementValidInputs(unittest.TestCase):
         github_service.github_client_rest_api = mock_github_client_rest_api
 
         github_service.add_new_user_to_github_org(
-            self.approved_email_address, [MINISTRY_OF_JUSTICE], False
+            self.test_email_address, [MINISTRY_OF_JUSTICE], False
         )
         mock_invite_user_to_org_using_email_address.assert_not_called()
 


### PR DESCRIPTION
## 👀 Purpose

- To fix the tests in `test_github_service.py` (inherited from `test_github_script.py` now refactored) that `assert_not_called` to `get_user` from `add_new_user_to_github_org` which never used `get_user` anyway - this was a copy paste error carried over from the function to rejoin a former user (also now removed).

## ♻️ What's changed

- Renamed test `TestGithubServiceUserManagementIncorrectInputs` to `TestGithubServiceUserManagementInvalidInputs` for consistency with `TestGithubServiceUserManagementValidInputs`.
- replaced `mock_get_user` with `mock_invite_user_to_org_using_email_address` and updated refs.
- reordered and refactored the tests to match the flow of logic in the if statement in `add_new_user_to_github_org` and to exhaustively test the possible combinations.
- removed refs to `self.approved_email_address` since `add_new_user_to_github_org` in no way checks the email address; neither for validity of email pattern nor for membership of approved list (this should perhaps be addressed in a separate ticket).
- fixed a lint complaint in `test_auth.py`

