### PR TITLE
🔧 Fix extra space in `deployment.yaml`

### DIFF
--- a/helm/join-github/templates/deployment.yaml
+++ b/helm/join-github/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "join-github.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.app.deployment.replicaCount } }
+  replicas: {{ .Values.app.deployment.replicaCount }}
   selector:
     matchLabels:
       {{- include "join-github.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
## 👀 Purpose

- Fix syntax error missed in https://github.com/ministryofjustice/operations-engineering-join-github/pull/141

## ♻️ What's changed

- Removed space