### PR TITLE
🔧 Fix missing `deployment` in value path

### DIFF
--- a/helm/join-github/templates/deployment.yaml
+++ b/helm/join-github/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: cd-serviceaccount
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.app.image.repository }}:{{ .Values.app.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.app.deployment.image.repository }}:{{ .Values.app.deployment.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: IfNotPresent
           env:
             - name: ADMIN_GITHUB_TOKEN


### PR DESCRIPTION
## 👀 Purpose

- Fix missing path to helm value in https://github.com/ministryofjustice/operations-engineering-join-github/pull/141

## ♻️ What's changed

- added `.app.` to the image and repository values in the template