### PR TITLE
Panel added to  invitation-sent page and redirects to clarify urls

### DIFF
--- a/join_github_app/app_config.py
+++ b/join_github_app/app_config.py
@@ -38,7 +38,7 @@ app_config = SimpleNamespace(
         ],
         organisations=[
             SimpleNamespace(
-                name="ministryofjustce",
+                name="ministryofjustice",
                 enabled=__get_env_var_as_boolean("MOJ_ORG_ENABLED"),
                 display_text="Ministry of Justice"
             ),
@@ -48,7 +48,7 @@ app_config = SimpleNamespace(
                 display_text="MoJ Analytical Services"
             ),
             SimpleNamespace(
-                name="ministryofjustce-test",
+                name="ministryofjustice-test",
                 enabled=__get_env_var_as_boolean("MOJ_TEST_ORG_ENABLED"),
                 display_text="Ministry of Justice Test Organisation"
             ),

--- a/join_github_app/main/routes/auth.py
+++ b/join_github_app/main/routes/auth.py
@@ -124,11 +124,6 @@ def send_github_invitation(email, org_selection):
         return False
 
 
-@join_route.route("/invitation-sent")
-def invitation_sent():
-    return render_template("pages/invitation-sent.html")
-
-
 @auth_route.route("/server-error")
 def server_error():
     return render_template("pages/errors/500.html"), 500

--- a/join_github_app/main/routes/auth.py
+++ b/join_github_app/main/routes/auth.py
@@ -68,6 +68,7 @@ def callback():
 
     if not send_github_invitation(original_email, org_selection):
         return redirect("/auth/server-error")
+        # return render_template("pages/errors/500.html"), 500
 
     return redirect("/join/invitation-sent")
 

--- a/join_github_app/main/routes/join.py
+++ b/join_github_app/main/routes/join.py
@@ -79,7 +79,21 @@ def join_selection():
 
 @join_route.route("/invitation-sent")
 def invitation_sent():
-    return render_template("pages/invitation-sent.html")
+    email = session.get("email", "").lower()
+    org_selection = session.get("org_selection", [])
+    if len(org_selection) == 1:
+        org_selection_string = org_selection[0]
+        template = "pages/invitation-sent.html"
+    else:
+        org_selection_string = f"{', '.join(org_selection[:-1])} and {org_selection[-1]}"
+        template = "pages/multiple-invitations-sent.html"
+    return render_template(
+        template,
+        org_selection_string=org_selection_string,
+        email=email
+    )
+
+
 
 
 @join_route.route("/submitted")

--- a/join_github_app/main/routes/join.py
+++ b/join_github_app/main/routes/join.py
@@ -79,7 +79,7 @@ def join_selection():
 
 @join_route.route("/invitation-sent")
 def invitation_sent():
-    email = session.get("email", "").lower()
+    auth0_email = session["user"].get("userinfo", {}).get("email").lower()
     org_selection = session.get("org_selection", [])
     if len(org_selection) == 1:
         org_selection_string = org_selection[0]
@@ -90,7 +90,7 @@ def invitation_sent():
     return render_template(
         template,
         org_selection_string=org_selection_string,
-        email=email
+        email=auth0_email
     )
 
 

--- a/join_github_app/main/routes/join.py
+++ b/join_github_app/main/routes/join.py
@@ -94,8 +94,6 @@ def invitation_sent():
     )
 
 
-
-
 @join_route.route("/submitted")
 def submitted():
     return render_template("pages/thank-you.html")

--- a/join_github_app/templates/components/base.html
+++ b/join_github_app/templates/components/base.html
@@ -7,6 +7,7 @@
 {% from 'govuk_frontend_jinja/components/footer/macro.html' import govukFooter %}
 {% from 'govuk_frontend_jinja/components/header/macro.html' import govukHeader %}
 {% from 'govuk_frontend_jinja/components/phase-banner/macro.html' import govukPhaseBanner %}
+{% from 'govuk_frontend_jinja/components/panel/macro.html' import govukPanel %}
 
 {% extends 'govuk_frontend_jinja/template.html' %}
 

--- a/join_github_app/templates/pages/errors/internal-error.html
+++ b/join_github_app/templates/pages/errors/internal-error.html
@@ -12,7 +12,7 @@
     </p>
 
     <p class="govuk-body">
-        If you require further assistance please contact the Operations-Engineering team on Slack <a
+        If you require further assistance please contact the Operations Engineering team on Slack <a
             href="https://mojdt.slack.com/archives/C01BUKJSZD4" class="govuk-link">#ask-operations-engineering</a> with
         details of the request and the error message.
     </p>

--- a/join_github_app/templates/pages/invitation-sent.html
+++ b/join_github_app/templates/pages/invitation-sent.html
@@ -4,14 +4,27 @@
     Thank you
 {% endblock %}
 
-{% block content %}
-    <h1 class="govuk-heading-xl">Thank you</h1>
+{% block beforeContent %}
+{{ super() }}
+{{ govukBackLink ({
+'text': 'Back',
+'href': '/home'
+}) }}
+{% endblock %}
 
-    <p class="govuk-body">
-        If you require further assistance contact us on the Operations-Engineering team Slack channel <a
-            href="https://mojdt.slack.com/archives/C01BUKJSZD4" class="govuk-link">#ask-operations-engineering</a>.
+{% block content %}
+
+    {{ govukPanel({
+        "titleText": "Invitation sent"
+    }) }}
+
+    <p class="govuk-body">We have sent an invitation to join XXXXXXXX GitHub Organisation to 
+        EMAIL@ADDRESS. Please check your inbox and follow the instructions in the email.
     </p>
 
-    <a href="/" class="govuk-back-link">Back</a>
+    <p class="govuk-body">
+        If you require further assistance contact us on the Operations Engineering team Slack channel <a
+            href="https://mojdt.slack.com/archives/C01BUKJSZD4" class="govuk-link">#ask-operations-engineering</a>.
+    </p>
 
 {% endblock %}

--- a/join_github_app/templates/pages/invitation-sent.html
+++ b/join_github_app/templates/pages/invitation-sent.html
@@ -1,7 +1,7 @@
 {% extends "components/base.html" %}
 
 {% block pageTitle %}
-    Thank you
+    Invitation sent
 {% endblock %}
 
 {% block beforeContent %}

--- a/join_github_app/templates/pages/multiple-invitations-sent.html
+++ b/join_github_app/templates/pages/multiple-invitations-sent.html
@@ -15,13 +15,13 @@
 {% block content %}
 
     {{ govukPanel({
-        'titleText': 'Invitation sent to',
+        'titleText': 'Invitations sent to',
         'html': email
     }) }}
 
     <p class="govuk-body">
-        Please find an email invite from GitHub in your inbox and follow
-        instructions to join the {{org_selection_string}} GitHub Organisation.
+        Please find email invites from GitHub in your inbox and follow
+        instructions to join the {{org_selection_string}} GitHub Organisations.
     </p>
     <p class="govuk-body">
         If you require further assistance contact us on the Operations Engineering team Slack channel <a

--- a/tests/routes/test_auth.py
+++ b/tests/routes/test_auth.py
@@ -51,7 +51,7 @@ class TestAuthRoutes(unittest.TestCase):
 
         self.assertIn('auth0.com/v2/logout', response.headers['Location'])
 
-    @patch("join_github_app.main.routes.auth.invitation_sent")
+    @patch("join_github_app.main.routes.join.invitation_sent")
     @patch("join_github_app.main.routes.auth.send_github_invitation", return_value=True)
     @patch("join_github_app.main.routes.auth.process_user_session", return_value=True)
     @patch("join_github_app.main.routes.auth.get_token")

--- a/tests/routes/test_auth.py
+++ b/tests/routes/test_auth.py
@@ -51,31 +51,31 @@ class TestAuthRoutes(unittest.TestCase):
 
         self.assertIn('auth0.com/v2/logout', response.headers['Location'])
 
-    @patch("join_github_app.main.routes.auth.render_success_page")
+    @patch("join_github_app.main.routes.auth.invitation_sent")
     @patch("join_github_app.main.routes.auth.send_github_invitation", return_value=True)
     @patch("join_github_app.main.routes.auth.process_user_session", return_value=True)
     @patch("join_github_app.main.routes.auth.get_token")
     def test_callback_route_success(self, mock_get_token, mock_process_user_session,
-                                    mock_send_github_invitation, mock_render_success_page):
+                                    mock_send_github_invitation, mock_invitation_sent):
         mock_get_token.return_value = {'userinfo': {'email': 'test@example.com'}}
-        mock_render_success_page.return_value = Response(status=200)
+        mock_invitation_sent.return_value = Response(status=200)
 
         response = self.client.get("/auth/callback")
         self.assertEqual(response.status_code, 200)
         mock_get_token.assert_called_once()
         mock_process_user_session.assert_called_once()
         mock_send_github_invitation.assert_called_once()
-        mock_render_success_page.assert_called_once()
+        mock_invitation_sent.assert_called_once()
 
-    @patch("join_github_app.main.routes.auth.render_error_page", return_value=Response(status=500))
+    @patch("join_github_app.main.routes.auth.server_error", return_value=Response(status=500))
     @patch("join_github_app.main.routes.auth.get_token")
-    def test_callback_route_token_failure(self, mock_get_token, mock_render_error_page):
+    def test_callback_route_token_failure(self, mock_get_token, mock_server_error):
         mock_get_token.side_effect = AuthTokenError("Token error")
 
         response = self.client.get("/auth/callback")
         self.assertEqual(response.status_code, 500)
         mock_get_token.assert_called_once()
-        mock_render_error_page.assert_called_once()
+        mock_server_error.assert_called_once()
 
     @patch("join_github_app.main.routes.auth.app_config.github.allowed_email_domains",
            new=["example.com", "test.com"])

--- a/tests/views/test_views.py
+++ b/tests/views/test_views.py
@@ -87,10 +87,26 @@ class TestViews(unittest.TestCase):
                 "disabled", str(response.data)
             )  # Check if the checkbox is disabled
 
-    def test_invitation_sent(self):
-        response = self.app.test_client().get("/join/invitation-sent")
+    def test_single_invitation_sent(self):
+        with self.app.test_client() as client:
+            with client.session_transaction() as sess:
+                sess["email"] = "user@email.com"
+                sess["org_selection"] = ["org1"]
+            response = client.get("/join/invitation-sent")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.request.path, "/join/invitation-sent")
+        self.assertIn("Invitation sent to", str(response.data))
+
+    def test_multiple_invitations_sent(self):
+        with self.app.test_client() as client:
+            with client.session_transaction() as sess:
+                sess["email"] = "user@email.com"
+                sess["org_selection"] = ["org1", "org2"]
+            response = client.get("/join/invitation-sent")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.request.path, "/join/invitation-sent")
+        self.assertIn("Invitations sent to", str(response.data))
+        self.assertIn("org1 and org2", str(response.data))
 
     def test_error(self):
         with self.app.test_request_context():

--- a/tests/views/test_views.py
+++ b/tests/views/test_views.py
@@ -90,7 +90,7 @@ class TestViews(unittest.TestCase):
     def test_single_invitation_sent(self):
         with self.app.test_client() as client:
             with client.session_transaction() as sess:
-                sess["email"] = "user@email.com"
+                sess["user"] = {'userinfo': {'email': 'test@example.com'}}
                 sess["org_selection"] = ["org1"]
             response = client.get("/join/invitation-sent")
         self.assertEqual(response.status_code, 200)
@@ -100,7 +100,7 @@ class TestViews(unittest.TestCase):
     def test_multiple_invitations_sent(self):
         with self.app.test_client() as client:
             with client.session_transaction() as sess:
-                sess["email"] = "user@email.com"
+                sess["user"] = {'userinfo': {'email': 'test@example.com'}}
                 sess["org_selection"] = ["org1", "org2"]
             response = client.get("/join/invitation-sent")
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## 👀 Purpose

- To improve the user journey by adding a confirmation page

## ♻️ What's changed

- 🎛️ Added panel to the invitation sent confirmation page using auth0 authenticated email
- ↩️ Added redirects to ensure the URLs are human readable and match point in user journey
- ✨ Created a page for when multiple invites are sent and logic
- ✏️ Fixed `justce` typo
- ♻️ Updated tests to account for redirects and test new `invitation-sent` logic

## 📝 Notes

-