### PR TITLE
Fix where user input email is used

### DIFF
--- a/join_github_app/main/routes/auth.py
+++ b/join_github_app/main/routes/auth.py
@@ -65,8 +65,6 @@ def callback():
 
     org_selection = session["org_selection"]
     auth0_email = session["user"]["userinfo"]["email"]
-    # org_selection = session.get("org_selection", [])
-    # auth0_email = session["user"].get("userinfo", {}).get("email")
 
     if not send_github_invitation(auth0_email, org_selection):
         return redirect("/auth/server-error")

--- a/join_github_app/main/routes/auth.py
+++ b/join_github_app/main/routes/auth.py
@@ -64,11 +64,11 @@ def callback():
         return redirect("/auth/server-error")
 
     org_selection = session.get("org_selection", [])
-    original_email = session.get("email")
+    # user_input_email = session.get("user_input_email")
+    auth0_email = session["user"].get("userinfo", {}).get("email")
 
-    if not send_github_invitation(original_email, org_selection):
+    if not send_github_invitation(auth0_email, org_selection):
         return redirect("/auth/server-error")
-        # return render_template("pages/errors/500.html"), 500
 
     return redirect("/join/invitation-sent")
 
@@ -90,15 +90,15 @@ def process_user_session():
 
     :return: True if session processing is successful, False otherwise.
     """
-    if 'user' not in session or 'email' not in session:
+    if 'user' not in session or 'user_input_email' not in session:
         logger.error("Missing user or email in session")
         return False
 
     auth0_email = session["user"].get("userinfo", {}).get("email")
-    original_email = session["email"]
+    user_input_email = session["user_input_email"]
     org_selection = session.get("org_selection", [])
 
-    if not auth0_email or not user_is_valid(auth0_email, original_email):
+    if not auth0_email or not user_is_valid(auth0_email, user_input_email):
         logger.error("Invalid email in session or email mismatch")
         return False
 
@@ -130,8 +130,8 @@ def server_error():
     return render_template("pages/errors/500.html"), 500
 
 
-def user_is_valid(auth0_email, original_email) -> bool:
-    if auth0_email.lower() != original_email.lower():
+def user_is_valid(auth0_email, user_input_email) -> bool:
+    if auth0_email.lower() != user_input_email.lower():
         return False
 
     if user_email_allowed(auth0_email):

--- a/join_github_app/main/routes/auth.py
+++ b/join_github_app/main/routes/auth.py
@@ -63,9 +63,10 @@ def callback():
         logger.debug("User session processing failed")
         return redirect("/auth/server-error")
 
-    org_selection = session.get("org_selection", [])
-    # user_input_email = session.get("user_input_email")
-    auth0_email = session["user"].get("userinfo", {}).get("email")
+    org_selection = session["org_selection"]
+    auth0_email = session["user"]["userinfo"]["email"]
+    # org_selection = session.get("org_selection", [])
+    # auth0_email = session["user"].get("userinfo", {}).get("email")
 
     if not send_github_invitation(auth0_email, org_selection):
         return redirect("/auth/server-error")

--- a/join_github_app/main/routes/join.py
+++ b/join_github_app/main/routes/join.py
@@ -10,12 +10,12 @@ join_route = Blueprint('join_route', __name__)
 @join_route.route("/submit-email", methods=["GET", "POST"])
 def submit_email():
     if request.method == "POST":
-        email = request.form.get("emailAddress", "Empty").strip()
-        if not is_valid_email_pattern(email):
+        user_input_email = request.form.get("emailAddress", "Empty").strip()
+        if not is_valid_email_pattern(user_input_email):
             flash("Please enter a valid email address.")
             return render_template("pages/submit-email.html")
-        session['email'] = email
-        domain = session["email"].split("@")[1]
+        session['user_input_email'] = user_input_email
+        domain = session["user_input_email"].split("@")[1]
         if domain in set(app_config.github.allowed_email_domains):
             return redirect("/join/select-organisations")
         else:
@@ -27,14 +27,14 @@ def submit_email():
 def outside_collaborator():
     return render_template(
         "pages/outside-collaborator.html",
-        email=session["email"],
+        email=session["user_input_email"],
     )
 
 
 @join_route.route("/select-organisations", methods=["GET", "POST"])
 def select_organisations():
-    email = session.get("email", "").lower()
-    domain = email[email.index("@") + 1:]
+    user_input_email = session.get("user_input_email", "").lower()
+    domain = user_input_email[user_input_email.index("@") + 1:]
     is_digital_justice_user = is_digital_justice_email(domain)
     enabled_organisations = [organisation for organisation in app_config.github.organisations if organisation.enabled]
 
@@ -64,8 +64,8 @@ def select_organisations():
 
 @join_route.route("/selection")
 def join_selection():
-    email = session.get("email", "").lower()
-    domain = email[email.index("@") + 1:]
+    user_input_email = session.get("user_input_email", "").lower()
+    domain = user_input_email[user_input_email.index("@") + 1:]
     org_selection = session.get("org_selection", [])
 
     if is_justice_email(domain):
@@ -74,7 +74,11 @@ def join_selection():
         template = "pages/digital-justice-user.html"
     else:
         template = "pages/join-selection.html"
-    return render_template(template, org_selection=org_selection, email=email)
+    return render_template(
+        template,
+        org_selection=org_selection,
+        email=user_input_email
+    )
 
 
 @join_route.route("/invitation-sent")

--- a/join_github_app/main/services/github_service.py
+++ b/join_github_app/main/services/github_service.py
@@ -24,4 +24,4 @@ class GithubService:
             if app_config.github.send_email_invites_is_enabled:
                 self.github_client_core_api.get_organization(organisation.lower()).invite_user(email=email)
             else:
-                logger.info("Did not send invitation for organisation [ %s ] as SEND_EMAIL_INVITES is [ %s ]", organisation, app_config.github.send_email_invites_is_enabled)
+                logger.info("Invitation for organisation [ %s ] not sent as SEND_EMAIL_INVITES is [ %s ]", organisation, app_config.github.send_email_invites_is_enabled)

--- a/join_github_app/main/services/github_service.py
+++ b/join_github_app/main/services/github_service.py
@@ -24,4 +24,4 @@ class GithubService:
             if app_config.github.send_email_invites_is_enabled:
                 self.github_client_core_api.get_organization(organisation.lower()).invite_user(email=email)
             else:
-                logger.info("Not sending invitation for organisation [ %s ] as SEND_EMAIL_INVITES is [ %s ]", organisation, app_config.github.send_email_invites_is_enabled)
+                logger.info("Did not send invitation for organisation [ %s ] as SEND_EMAIL_INVITES is [ %s ]", organisation, app_config.github.send_email_invites_is_enabled)

--- a/tests/routes/test_auth.py
+++ b/tests/routes/test_auth.py
@@ -81,7 +81,7 @@ class TestAuthRoutes(unittest.TestCase):
     def test_process_user_session_success(self):
         with self.app.test_request_context('/auth/callback'):
             session['user'] = {'userinfo': {'email': 'user@test.com'}}
-            session['email'] = 'user@test.com'
+            session['user_input_email'] = 'user@test.com'
             session['org_selection'] = ['some_org']
 
             result = process_user_session()

--- a/tests/views/test_views.py
+++ b/tests/views/test_views.py
@@ -58,7 +58,7 @@ class TestViews(unittest.TestCase):
     def test_join_selection_digital_justice_user(self):
         with self.app.test_client() as client:
             with client.session_transaction() as sess:
-                sess["email"] = "user@digital.justice.gov.uk"
+                sess["user_input_email"] = "user@digital.justice.gov.uk"
                 sess["org_selection"] = ["ministryofjustice"]
 
             response = client.get("/join/selection")
@@ -68,7 +68,7 @@ class TestViews(unittest.TestCase):
     def test_join_selection_justice_user(self):
         with self.app.test_client() as client:
             with client.session_transaction() as sess:
-                sess["email"] = "user@justice.gov.uk"
+                sess["user_input_email"] = "user@justice.gov.uk"
                 sess["org_selection"] = ["ministryofjustice"]
 
             response = client.get("/join/selection")
@@ -79,7 +79,7 @@ class TestViews(unittest.TestCase):
     def test_select_organisations_digital_justice_user(self):
         with self.app.test_client() as client:
             with client.session_transaction() as sess:
-                sess["email"] = "user@digital.justice.gov.uk"
+                sess["user_input_email"] = "user@digital.justice.gov.uk"
             response = client.get("/join/select-organisations")
             self.assertEqual(response.status_code, 200)
             self.assertIn("MoJ Analytical Services", str(response.data))


### PR DESCRIPTION
## 👀 Purpose

- To reduce vulnerability to attack by using the auth0 authenticated email to send GitHub invite

## ♻️ What's changed

- ♻️ Replaced instances of user input email with `user_input_email` rather than `email` to clarify where it is used
- 🔐 Pass `auth0_email` to `send_github_invitation()` instead of `user_input_email`
- ✏️ Grammar fix; present continuous -> past simple (not sending -> not sent) since the action has finished; it is not ongoing.
- ♻️ Replaced `.get()` dict method with `[]` so that the `unknown key` error raises if empty.
- 🧪 Updated tests to deal with `[]` rather than `.get()` 

## 📝 Notes

-