### PR TITLE
♻️ Refactor validation logic into `join` route

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -10,6 +10,7 @@ from sentry_sdk.integrations.flask import FlaskIntegration
 
 from app.app_config import app_config
 from app.main.middleware.error_handler import (
+    client_error,
     page_not_found,
     server_forbidden,
     unknown_server_error,
@@ -18,6 +19,7 @@ from app.main.routes.auth import auth_route
 from app.main.routes.join import join_route
 from app.main.routes.main import main
 from app.main.routes.robots import robot_route
+from app.main.services.auth0_service import Auth0_Service
 from app.main.services.github_service import GithubService
 
 
@@ -71,6 +73,7 @@ def create_app(
     app.jinja_env.lstrip_blocks = True
     app.jinja_env.globals["phase_banner_text"] = app_config.phase_banner_text
 
+    app.register_error_handler(400, client_error)
     app.register_error_handler(403, server_forbidden)
     app.register_error_handler(404, page_not_found)
     app.register_error_handler(500, unknown_server_error)
@@ -78,6 +81,12 @@ def create_app(
     CORS(app, resources={r"/*": {"origins": "*", "send_wildcard": "False"}})
 
     app.github_service = github_service
+    app.auth0_service = Auth0_Service(
+        app,
+        app_config.auth0.client_id,
+        app_config.auth0.client_secret,
+        app_config.auth0.domain,
+    )
 
     app.logger.info("App Setup complete, running App...")
     return app

--- a/app/main/middleware/error_handler.py
+++ b/app/main/middleware/error_handler.py
@@ -5,6 +5,11 @@ from flask import render_template
 logger = logging.getLogger(__name__)
 
 
+def client_error(err: Exception):
+    logger.error("There was an error with the client request %s", err)
+    return render_template("pages/errors/400.html", error_message=str(err)), 400
+
+
 def page_not_found(err: Exception):
     logger.error("A request was made to a page that doesn't exist %s", err)
     return render_template("pages/errors/404.html"), 404

--- a/app/main/routes/auth.py
+++ b/app/main/routes/auth.py
@@ -1,143 +1,34 @@
 import logging
-from urllib.parse import quote_plus, urlencode
 
-from authlib.integrations.flask_client import OAuth
-from flask import Blueprint, current_app, redirect, render_template, session, url_for
+from flask import Blueprint, current_app, redirect, session, url_for
 
 from app.app_config import app_config
-from app.main.middleware.error_handler import AuthTokenError
+from app.main.services.auth0_service import Auth0_Service
 
 logger = logging.getLogger(__name__)
 
 auth_route = Blueprint("auth_routes", __name__)
-join_route = Blueprint('join_route', __name__)
 
-oauth = OAuth(current_app)
-oauth.register(
-    "auth0",
-    client_id=app_config.auth0.client_id,
-    client_secret=app_config.auth0.client_secret,
-    client_kwargs={
-        "scope": "openid profile email",
-    },
-    server_metadata_url=f"https://{app_config.auth0.domain}/.well-known/openid-configuration",
+auth0_service = Auth0_Service(
+    current_app,
+    app_config.auth0.client_id,
+    app_config.auth0.client_secret,
+    app_config.auth0.domain,
 )
 
 
 @auth_route.route("/login")
 def login():
-    return oauth.auth0.authorize_redirect(
-        redirect_uri=url_for("auth_routes.callback", _external=True)
-    )
+    return auth0_service.login(url_for("auth_routes.callback", _external=True))
 
 
 @auth_route.route("/logout", methods=["GET", "POST"])
 def logout():
     session.clear()
-    return redirect(
-        "https://"
-        + app_config.auth0.domain
-        + "/v2/logout?"
-        + urlencode(
-            {
-                "returnTo": url_for("main.index", _external=True),
-                "client_id": app_config.auth0.client_id,
-            },
-            quote_via=quote_plus,
-        )
-    )
+    auth0_service.logout(url_for("main.index", _external=True))
 
 
 @auth_route.route("/callback", methods=["GET", "POST"])
 def callback():
-    try:
-        token = get_token()
-        session["user"] = token
-    except AuthTokenError:
-        return redirect("/auth/server-error")
-
-    if not process_user_session():
-        logger.debug("User session processing failed")
-        return redirect("/auth/server-error")
-
-    org_selection = session["org_selection"]
-    auth0_email = session["user"]["userinfo"]["email"]
-
-    if not send_github_invitation(auth0_email, org_selection):
-        return redirect("/auth/server-error")
-
-    return redirect("/join/invitation-sent")
-
-
-def get_token():
-    try:
-        token = oauth.auth0.authorize_access_token()
-        if not token:
-            raise AuthTokenError("No token received from Auth0")
-        return token
-    except Exception as e:
-        logger.error("Error retrieving token: %s", e)
-        raise AuthTokenError("Error retrieving token from Auth0") from e
-
-
-def process_user_session():
-    """
-    Process and validate user session data.
-
-    :return: True if session processing is successful, False otherwise.
-    """
-    if 'user' not in session or 'user_input_email' not in session:
-        logger.error("Missing user or email in session")
-        return False
-
-    auth0_email = session["user"].get("userinfo", {}).get("email")
-    user_input_email = session["user_input_email"]
-    org_selection = session.get("org_selection", [])
-
-    if not auth0_email or not user_is_valid(auth0_email, user_input_email):
-        logger.error("Invalid email in session or email mismatch")
-        return False
-
-    if not org_selection:
-        logger.debug("No organisations selected")
-        return False
-
-    return True
-
-
-def send_github_invitation(email, org_selection):
-    """
-    Send an invitation to the specified GitHub organisation(s).
-
-    :param email: Email of the user to send the invitation to.
-    :param org_selection: List of organizations to invite the user to.
-    :return: True if the invitation was sent successfully, False otherwise.
-    """
-    try:
-        current_app.github_service.send_invites_to_user_email(email, org_selection)
-        return True
-    except Exception as e:
-        logger.error("Error sending GitHub invitation: %s", e)
-        return False
-
-
-@auth_route.route("/server-error")
-def server_error():
-    return render_template("pages/errors/500.html"), 500
-
-
-def user_is_valid(auth0_email, user_input_email) -> bool:
-    if auth0_email.lower() != user_input_email.lower():
-        return False
-
-    if user_email_allowed(auth0_email):
-        return True
-
-    return False
-
-
-def user_email_allowed(email) -> bool:
-    domain = email[email.index("@") + 1 :]
-    if domain in app_config.github.allowed_email_domains:
-        return True
-    return False
+    session["user"] = auth0_service.get_access_token()
+    return redirect("/join/send-invitation")

--- a/app/main/routes/auth.py
+++ b/app/main/routes/auth.py
@@ -25,7 +25,7 @@ def login():
 @auth_route.route("/logout", methods=["GET", "POST"])
 def logout():
     session.clear()
-    auth0_service.logout(url_for("main.index", _external=True))
+    return auth0_service.logout(url_for("main.index", _external=True))
 
 
 @auth_route.route("/callback", methods=["GET", "POST"])

--- a/app/main/routes/join.py
+++ b/app/main/routes/join.py
@@ -1,7 +1,9 @@
 import logging
+from typing import Any
 
 from flask import (
     Blueprint,
+    abort,
     current_app,
     flash,
     redirect,
@@ -61,17 +63,19 @@ def select_organisations():
     ]
 
     if request.method == "POST":
-        session["org_selection"] = sanitize_org_selection(
+        sanitised_org_selection = sanitise_org_selection(
             request.form.getlist("organisation_selection")
         )
 
-        if not session["org_selection"]:
+        if not sanitised_org_selection:
             flash("Please select at least one organisation.")
             return render_template(
                 "pages/select-organisations.html",
                 checkboxes_items=checkboxes_items,
                 is_digital_justice_user=is_digital_justice_user,
             )
+
+        session["org_selection"] = sanitised_org_selection
         return redirect("/join/selection")
 
     return render_template(
@@ -102,7 +106,7 @@ def join_selection():
 @join_route.route("/invitation-sent")
 def invitation_sent():
     auth0_email = session["user"]["userinfo"]["email"].lower()
-    org_selection = sanitize_org_selection(session["org_selection"])
+    org_selection = sanitise_org_selection(session["org_selection"])
     if len(org_selection) == 1:
         org_selection_string = org_selection[0]
         template = "pages/invitation-sent.html"
@@ -111,6 +115,9 @@ def invitation_sent():
             f"{', '.join(org_selection[:-1])} and {org_selection[-1]}"
         )
         template = "pages/multiple-invitations-sent.html"
+
+    session.clear()
+
     return render_template(
         template, org_selection_string=org_selection_string, email=auth0_email
     )
@@ -121,20 +128,20 @@ def invitation_sent():
 def send_invitation():
     auth0_email = session["user"]["userinfo"]["email"]
     user_input_email = session["user_input_email"]
-    org_selection = sanitize_org_selection(session["org_selection"])
+    org_selection = sanitise_org_selection(session["org_selection"])
 
     if user_input_email.lower() != auth0_email.lower():
-        raise ValueError("Users initial email does not match authenticated email")
+        abort(400, "Users initial email does not match authenticated email")
 
     if not is_pre_approved_email_domain(auth0_email):
-        raise ValueError("Users email domain is not pre-approved")
+        abort(400, "Users email domain is not pre-approved")
 
     current_app.github_service.send_invites_to_user_email(auth0_email, org_selection)
 
     return redirect(url_for("join_route.invitation_sent"))
 
 
-def get_enabled_organisations():
+def get_enabled_organisations() -> list[Any]:
     return [
         organisation
         for organisation in app_config.github.organisations
@@ -142,7 +149,7 @@ def get_enabled_organisations():
     ]
 
 
-def get_enabled_organisations_names():
+def get_enabled_organisations_names() -> list[str]:
     return [
         organisation.name
         for organisation in app_config.github.organisations
@@ -150,7 +157,7 @@ def get_enabled_organisations_names():
     ]
 
 
-def sanitize_org_selection(org_selection: list[str]):
+def sanitise_org_selection(org_selection: list[str]) -> list[str]:
     enabled_organisation_names = get_enabled_organisations_names()
 
     sanitised_org_selection = []
@@ -158,21 +165,21 @@ def sanitize_org_selection(org_selection: list[str]):
         if org_name in enabled_organisation_names:
             sanitised_org_selection.append(org_name)
         else:
-            raise ValueError(
-                f"Organisation of [ {org_name} ] is not enabled for selection"
+            logger.warn(
+                f"Organisation [ {org_name} ] is not enabled for selection and has been filtered out"
             )
 
     return sanitised_org_selection
 
 
-def is_pre_approved_email_domain(email) -> bool:
+def is_pre_approved_email_domain(email: str) -> bool:
     domain = email[email.index("@") + 1 :]
     return True if domain in app_config.github.allowed_email_domains else False
 
 
-def is_digital_justice_email(domain):
+def is_digital_justice_email(domain: str) -> bool:
     return "digital.justice.gov.uk" == domain.lower()
 
 
-def is_justice_email(domain):
+def is_justice_email(domain: str) -> bool:
     return "justice.gov.uk" == domain.lower()

--- a/app/main/routes/join.py
+++ b/app/main/routes/join.py
@@ -131,10 +131,10 @@ def send_invitation():
     org_selection = sanitise_org_selection(session["org_selection"])
 
     if user_input_email.lower() != auth0_email.lower():
-        abort(400, "Users initial email does not match authenticated email")
+        abort(400, "Initial email does not match authenticated email")
 
     if not is_pre_approved_email_domain(auth0_email):
-        abort(400, "Users email domain is not pre-approved")
+        abort(400, "Email domain is not pre-approved")
 
     current_app.github_service.send_invites_to_user_email(auth0_email, org_selection)
 

--- a/app/main/services/auth0_service.py
+++ b/app/main/services/auth0_service.py
@@ -1,0 +1,44 @@
+import logging
+from typing import Any
+from urllib.parse import quote_plus, urlencode
+
+from authlib.integrations.flask_client import OAuth
+from flask import Flask, redirect
+
+logger = logging.getLogger(__name__)
+
+
+class Auth0_Service:
+    def __init__(
+        self, app: Flask, client_id: str, client_secret: str, domain: str
+    ) -> None:
+        self.client_id = client_id
+        self.domain = domain
+        self.oauth = OAuth(app)
+        self.oauth.register(
+            "auth0",
+            client_id=client_id,
+            client_secret=client_secret,
+            client_kwargs={
+                "scope": "openid profile email",
+            },
+            server_metadata_url=f"https://{domain}/.well-known/openid-configuration",
+        )
+
+    def login(self, redirect_uri: str) -> Any:
+        return self.oauth.auth0.authorize_redirect(
+            redirect_uri=redirect_uri, _external=True
+        )
+
+    def get_access_token(self) -> Any:
+        return self.oauth.auth0.authorize_access_token()
+
+    def logout(self, redirect_uri: str) -> Any:
+        query_parameters = urlencode(
+            {
+                "returnTo": redirect_uri,
+                "client_id": self.client_id,
+            },
+            quote_via=quote_plus,
+        )
+        return redirect(f"https://${self.domain}/v2/logout?${query_parameters}")

--- a/app/templates/pages/errors/400.html
+++ b/app/templates/pages/errors/400.html
@@ -1,0 +1,14 @@
+{% extends "components/base.html" %}
+
+{% block pageTitle %}
+There was an issue with your request (400)
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">There was an issue with your request (400)</h1>
+        <p class="govuk-body">{{ error_message }}</p>
+    </div>
+</div>
+{% endblock %}

--- a/tests/routes/test_auth.py
+++ b/tests/routes/test_auth.py
@@ -1,17 +1,10 @@
 import unittest
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from flask import Response, session
+from flask import Response
 
 from app.app import create_app
 from app.main.middleware.error_handler import AuthTokenError
-from app.main.routes.auth import (
-    process_user_session,
-    send_github_invitation,
-    user_email_allowed,
-    user_is_valid,
-)
 from app.main.services.github_service import GithubService
 
 
@@ -27,167 +20,44 @@ class TestAuthRoutes(unittest.TestCase):
     def tearDown(self):
         self.ctx.pop()
 
-    @patch("app.main.routes.auth.oauth.auth0.authorize_redirect")
-    def test_login_route(self, mock_authorize_redirect):
-        mock_response = Response(
+    @patch("app.main.routes.auth.auth0_service")
+    def test_login_route_redirects(self, mock_auth0_service):
+        mock_auth0_service.login.return_value = Response(
             status=302, headers={"Location": "mock://auth0.redirect"}
         )
-        mock_authorize_redirect.return_value = mock_response
 
         response = self.client.get("/auth/login")
-        self.assertEqual(response.status_code, 302)
-        mock_authorize_redirect.assert_called_once()
 
-    @patch(
-        "app.main.routes.auth.app_config",
-        new=SimpleNamespace(
-            auth0=SimpleNamespace(client_id="test_id", domain="auth0.com")
-        ),
-    )
-    def test_logout_route_redirects_and_clears_session_data(self):
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("mock://auth0.redirect", response.headers["Location"])
+        mock_auth0_service.login.assert_called_once()
+
+    @patch("app.main.routes.auth.auth0_service")
+    def test_callback_route_stores_users_session_and_redirects(
+        self, mock_auth0_service
+    ):
+        mock_auth0_service.get_access_token.return_value = "The users session! 🤩"
+
+        response = self.client.get("/auth/callback")
+
+        self.assertEqual(response.status_code, 302)
         with self.client.session_transaction() as session:
-            session["user"] = {"some": "data"}
+            self.assertEqual(session["user"], "The users session! 🤩")
+        self.assertIn("join/send-invitation", response.headers["Location"])
+
+    @patch("app.main.routes.auth.auth0_service")
+    def test_logout_route_clears_session_and_redirects(self, mock_auth0_service):
+        mock_auth0_service.logout.return_value = Response(
+            status=302, headers={"Location": "/"}
+        )
 
         response = self.client.get("/auth/logout")
 
-        self.assertEqual(response.status_code, 302)
         with self.client.session_transaction() as session:
-            self.assertNotIn("user", session)
-        self.assertIn("auth0.com/v2/logout", response.headers["Location"])
-
-    @patch("app.main.routes.join.invitation_sent")
-    @patch("app.main.routes.auth.send_github_invitation", return_value=True)
-    @patch("app.main.routes.auth.process_user_session", return_value=True)
-    @patch("app.main.routes.auth.get_token")
-    def test_callback_route_success(
-        self,
-        mock_get_token,
-        mock_process_user_session,
-        mock_send_github_invitation,
-        mock_invitation_sent,
-    ):
-        mock_get_token.return_value = {"userinfo": {"email": "test@example.com"}}
-        mock_invitation_sent.return_value = Response(status=302)
-
-        with self.client as c:
-            with c.session_transaction() as sess:
-                sess["org_selection"] = ["some-org"]
-
-            response = self.client.get("/auth/callback")
-
+            self.assertEqual(session.get("user", None), None)
+        self.assertIn("/", response.headers["Location"])
         self.assertEqual(response.status_code, 302)
-        self.assertIn("join/invitation-sent", response.headers["Location"])
-        mock_get_token.assert_called_once()
-        mock_process_user_session.assert_called_once()
-        mock_send_github_invitation.assert_called_once()
-
-    @patch("app.main.routes.auth.get_token")
-    def test_callback_route_token_failure(self, mock_get_token):
-        mock_get_token.side_effect = AuthTokenError("Token error")
-
-        response = self.client.get("/auth/callback")
-        self.assertIn("/auth/server-error", response.headers["Location"])
-        self.assertEqual(response.status_code, 302)
-        mock_get_token.assert_called_once()
-
-    @patch(
-        "app.main.routes.auth.app_config.github.allowed_email_domains",
-        new=["example.com", "test.com"],
-    )
-    def test_process_user_session_success(self):
-        with self.app.test_request_context("/auth/callback"):
-            session["user"] = {"userinfo": {"email": "user@test.com"}}
-            session["user_input_email"] = "user@test.com"
-            session["org_selection"] = ["some_org"]
-
-            result = process_user_session()
-            self.assertTrue(result)
-
-    def test_process_user_session_without_session(self):
-        with self.app.test_request_context("/auth/callback"):
-            session["user"] = {"userinfo": {"email": ""}}
-            session["email"] = ""
-            session["org_selection"] = [""]
-
-            result = process_user_session()
-            self.assertFalse(result)
-
-    def test_process_user_session_without_approved_email(self):
-        with self.app.test_request_context("/auth/callback"):
-            session["user"] = {"userinfo": {"email": "user@test.com"}}
-            session["email"] = "user@test.com"
-            session["org_selection"] = ["some_org"]
-
-            result = process_user_session()
-            self.assertFalse(result)
-
-    @patch(
-        "app.main.routes.auth.app_config.github.allowed_email_domains",
-        new=["example.com", "test.com"],
-    )
-    def test_process_user_session_with_mismatched_user_email(self):
-        with self.app.test_request_context("/auth/callback"):
-            session["user"] = {"userinfo": {"email": "user@test.com"}}
-            session["email"] = "user@test2.com"
-            session["org_selection"] = ["some_org"]
-
-            result = process_user_session()
-            self.assertFalse(result)
-
-    @patch(
-        "app.main.routes.auth.app_config.github.allowed_email_domains",
-        new=["example.com", "test.com"],
-    )
-    def test_process_user_session_with_missing_org_selection(self):
-        with self.app.test_request_context("/auth/callback"):
-            session["user"] = {"userinfo": {"email": "user@test.com"}}
-            session["email"] = "user@test.com"
-            session["org_selection"] = []
-
-            result = process_user_session()
-            self.assertFalse(result)
-
-    def test_send_github_invitation_success(self):
-        self.app.github_service.send_invites_to_user_email = MagicMock(
-            return_value=None
-        )
-
-        result = send_github_invitation("test@example.com", ["org1", "org2"])
-
-        self.assertTrue(result)
-
-        self.app.github_service.send_invites_to_user_email.assert_called_once_with(
-            "test@example.com", ["org1", "org2"]
-        )
-
-    def test_send_github_invitation_fail(self):
-        self.app.github_service.send_invites_to_user_email = MagicMock(
-            side_effect=Exception("Some error")
-        )
-
-        result = send_github_invitation("test@example.com", ["org1", "org2"])
-
-        self.assertFalse(result)
-
-
-class TestUserValidation(unittest.TestCase):
-    @patch("app.main.routes.auth.user_email_allowed", return_value=True)
-    def test_user_is_valid_matching_emails(self, mock_user_email_allowed):
-        self.assertTrue(user_is_valid("test@example.com", "test@example.com"))
-
-    @patch("app.main.routes.auth.user_email_allowed", return_value=False)
-    def test_user_is_valid_non_matching_emails(self, mock_user_email_allowed):
-        self.assertFalse(user_is_valid("test@example.com", "other@example.com"))
-
-
-class TestEmailAllowed(unittest.TestCase):
-    @patch(
-        "app.main.routes.auth.app_config.github.allowed_email_domains",
-        new=["example.com"],
-    )
-    def test_user_email_allowed(self):
-        self.assertTrue(user_email_allowed("user@example.com"))
-        self.assertFalse(user_email_allowed("user@notallowed.com"))
+        mock_auth0_service.logout.assert_called_with("http://localhost/")
 
 
 if __name__ == "__main__":

--- a/tests/routes/test_join.py
+++ b/tests/routes/test_join.py
@@ -1,0 +1,190 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from flask import get_flashed_messages
+
+from app.app import create_app
+from app.main.services.github_service import GithubService
+
+
+class TestSubmitEmail(unittest.TestCase):
+    def setUp(self):
+        self.github_service = MagicMock(GithubService)
+        self.app = create_app(self.github_service, False)
+        self.app.config["SECRET_KEY"] = "test_flask"
+        self.client = self.app.test_client()
+
+    def test_page_loads(self):
+        response = self.app.test_client().get("/join/submit-email")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.request.path, "/join/submit-email")
+
+    def test_join_github_invalid_email_flashes_warning(self):
+        form_data = {"emailAddress": ""}
+        expected_flashed_message = "Please enter a valid email address."
+
+        with self.app.test_client() as client:
+            response = client.post("/join/submit-email", data=form_data)
+            flashed_message = dict(get_flashed_messages(with_categories=True))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.request.path, "/join/submit-email")
+        self.assertEqual(flashed_message.get("message"), expected_flashed_message)
+
+    def test_redirects_to_select_organisation_when_email_is_pre_approved(self):
+        form_data = {"emailAddress": "email@digital.justice.gov.uk"}
+
+        with self.app.test_client() as client:
+            response = client.post("/join/submit-email", data=form_data)
+            flashed_message = dict(get_flashed_messages(with_categories=True))
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.request.path, "/join/submit-email")
+        self.assertEqual(response.headers["Location"], "/join/select-organisations")
+        self.assertEqual(flashed_message.get("message"), None)
+
+    def test_redirects_to_outside_collaborators_when_email_is_not_pre_approved(self):
+        form_data = {"emailAddress": "email@example.com"}
+
+        with self.app.test_client() as client:
+            response = client.post("/join/submit-email", data=form_data)
+            flashed_message = dict(get_flashed_messages(with_categories=True))
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.request.path, "/join/submit-email")
+        self.assertEqual(response.headers["Location"], "/join/outside-collaborator")
+        self.assertEqual(flashed_message.get("message"), None)
+
+
+class TestSelectOrganisation(unittest.TestCase):
+    def setUp(self):
+        self.github_service = MagicMock(GithubService)
+        self.app = create_app(self.github_service, False)
+        self.app.config["SECRET_KEY"] = "test_flask"
+        self.client = self.app.test_client()
+
+    @patch(
+        "app.main.routes.join.app_config",
+        new=SimpleNamespace(
+            github=SimpleNamespace(
+                organisations=[
+                    SimpleNamespace(
+                        name="moj-analytical-services",
+                        enabled=True,
+                        display_text="MoJ Analytical Services",
+                    )
+                ]
+            )
+        ),
+    )
+    def test_select_organisations_digital_justice_user(self):
+        with self.client.session_transaction() as sess:
+            sess["user_input_email"] = "user@digital.justice.gov.uk"
+
+        response = self.client.get("/join/select-organisations")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("MoJ Analytical Services", str(response.data))
+        self.assertIn(
+            "disabled", str(response.data)
+        )  # Check if the checkbox is disabled
+
+
+class TestSelection(unittest.TestCase):
+    def setUp(self):
+        self.github_service = MagicMock(GithubService)
+        self.app = create_app(self.github_service, False)
+        self.app.config["SECRET_KEY"] = "test_flask"
+        self.client = self.app.test_client()
+
+    def test_join_selection_digital_justice_user(self):
+        with self.client.session_transaction() as sess:
+            sess["user_input_email"] = "user@digital.justice.gov.uk"
+            sess["org_selection"] = ["ministryofjustice"]
+
+        response = self.client.get("/join/selection")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Using Single Sign-On", str(response.data))
+
+    def test_join_selection_justice_user(self):
+        with self.client.session_transaction() as sess:
+            sess["user_input_email"] = "user@justice.gov.uk"
+            sess["org_selection"] = ["ministryofjustice"]
+
+        response = self.client.get("/join/selection")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Azure", str(response.data))
+
+
+class TestInvitationSent(unittest.TestCase):
+    def setUp(self):
+        self.github_service = MagicMock(GithubService)
+        self.app = create_app(self.github_service, False)
+        self.app.config["SECRET_KEY"] = "test_flask"
+        self.client = self.app.test_client()
+
+    @patch(
+        "app.main.routes.join.app_config",
+        new=SimpleNamespace(
+            github=SimpleNamespace(
+                organisations=[
+                    SimpleNamespace(
+                        name="ministryofjustice",
+                        enabled=True,
+                        display_text="Ministry of Justice",
+                    )
+                ]
+            )
+        ),
+    )
+    def test_single_invitation_sent(self):
+        with self.client.session_transaction() as sess:
+            sess["user"] = {"userinfo": {"email": "test@justice.gov.uk"}}
+            sess["org_selection"] = ["ministryofjustice"]
+
+        response = self.client.get("/join/invitation-sent")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.request.path, "/join/invitation-sent")
+        self.assertIn("ministryofjustice", str(response.data))
+
+    @patch(
+        "app.main.routes.join.app_config",
+        new=SimpleNamespace(
+            github=SimpleNamespace(
+                organisations=[
+                    SimpleNamespace(
+                        name="ministryofjustice",
+                        enabled=True,
+                        display_text="Ministry of Justice",
+                    ),
+                    SimpleNamespace(
+                        name="moj-analytical-services",
+                        enabled=True,
+                        display_text="MoJ Analytical Services",
+                    ),
+                ]
+            )
+        ),
+    )
+    def test_multiple_invitations_sent(self):
+        with self.client.session_transaction() as sess:
+            sess["user"] = {"userinfo": {"email": "test@justice.gov.uk"}}
+            sess["org_selection"] = ["ministryofjustice", "moj-analytical-services"]
+
+        response = self.client.get("/join/invitation-sent")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.request.path, "/join/invitation-sent")
+        self.assertIn("Invitations sent to", str(response.data))
+        self.assertIn(
+            "ministryofjustice and moj-analytical-services", str(response.data)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/views/test_views.py
+++ b/tests/views/test_views.py
@@ -1,8 +1,5 @@
 import unittest
-from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
-
-from flask import get_flashed_messages
+from unittest.mock import MagicMock
 
 from app.app import create_app
 from app.main.services.github_service import GithubService
@@ -13,6 +10,7 @@ class TestViews(unittest.TestCase):
         self.github_service = MagicMock(GithubService)
         self.app = create_app(self.github_service, False)
         self.app.config["SECRET_KEY"] = "test_flask"
+        self.client = self.app.test_client()
 
     def test_default(self):
         response = self.app.test_client().get("/")
@@ -23,107 +21,6 @@ class TestViews(unittest.TestCase):
         response = self.app.test_client().get("/robots.txt")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.request.path, "/robots.txt")
-
-    def test_join_github_info_page(self):
-        response = self.app.test_client().get("/join/submit-email")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.request.path, "/join/submit-email")
-
-    def test_join_github_invalid_email_flashes_warning(self):
-        form_data = {"emailAddress": ""}
-        expected_flashed_message = "Please enter a valid email address."
-        with self.app.test_client() as client:
-            response = client.post("/join/submit-email", data=form_data)
-            flashed_message = dict(get_flashed_messages(with_categories=True))
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.request.path, "/join/submit-email")
-        self.assertEqual(flashed_message.get("message"), expected_flashed_message)
-
-    def test_join_github_allowed_email(self):
-        form_data = {"emailAddress": "email@digital.justice.gov.uk"}
-        with self.app.test_client() as client:
-            response = client.post("/join/submit-email", data=form_data)
-            flashed_message = dict(get_flashed_messages(with_categories=True))
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.request.path, "/join/submit-email")
-        self.assertEqual(response.headers["Location"], "/join/select-organisations")
-        self.assertEqual(flashed_message.get("message"), None)
-
-    def test_join_github_outside_collab_email(self):
-        form_data = {"emailAddress": "cat@dog.com"}
-        with self.app.test_client() as client:
-            response = client.post("/join/submit-email", data=form_data)
-            flashed_message = dict(get_flashed_messages(with_categories=True))
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.request.path, "/join/submit-email")
-        self.assertEqual(response.headers["Location"], "/join/outside-collaborator")
-        self.assertEqual(flashed_message.get("message"), None)
-
-    def test_join_selection_digital_justice_user(self):
-        with self.app.test_client() as client:
-            with client.session_transaction() as sess:
-                sess["user_input_email"] = "user@digital.justice.gov.uk"
-                sess["org_selection"] = ["ministryofjustice"]
-
-            response = client.get("/join/selection")
-            self.assertEqual(response.status_code, 200)
-            self.assertIn("Using Single Sign-On", str(response.data))
-
-    def test_join_selection_justice_user(self):
-        with self.app.test_client() as client:
-            with client.session_transaction() as sess:
-                sess["user_input_email"] = "user@justice.gov.uk"
-                sess["org_selection"] = ["ministryofjustice"]
-
-            response = client.get("/join/selection")
-            self.assertEqual(response.status_code, 200)
-            self.assertIn("Azure", str(response.data))
-
-    @patch(
-        "app.main.routes.join.app_config",
-        new=SimpleNamespace(
-            github=SimpleNamespace(
-                organisations=[
-                    SimpleNamespace(
-                        name="moj-analytical-services",
-                        enabled=True,
-                        display_text="MoJ Analytical Services",
-                    )
-                ]
-            )
-        ),
-    )
-    def test_select_organisations_digital_justice_user(self):
-        with self.app.test_client() as client:
-            with client.session_transaction() as sess:
-                sess["user_input_email"] = "user@digital.justice.gov.uk"
-            response = client.get("/join/select-organisations")
-            self.assertEqual(response.status_code, 200)
-            self.assertIn("MoJ Analytical Services", str(response.data))
-            self.assertIn(
-                "disabled", str(response.data)
-            )  # Check if the checkbox is disabled
-
-    def test_single_invitation_sent(self):
-        with self.app.test_client() as client:
-            with client.session_transaction() as sess:
-                sess["user"] = {"userinfo": {"email": "test@example.com"}}
-                sess["org_selection"] = ["org1"]
-            response = client.get("/join/invitation-sent")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.request.path, "/join/invitation-sent")
-        self.assertIn("Invitation sent to", str(response.data))
-
-    def test_multiple_invitations_sent(self):
-        with self.app.test_client() as client:
-            with client.session_transaction() as sess:
-                sess["user"] = {"userinfo": {"email": "test@example.com"}}
-                sess["org_selection"] = ["org1", "org2"]
-            response = client.get("/join/invitation-sent")
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.request.path, "/join/invitation-sent")
-        self.assertIn("Invitations sent to", str(response.data))
-        self.assertIn("org1 and org2", str(response.data))
 
 
 class TestCompletedRateLimit(unittest.TestCase):


### PR DESCRIPTION
## 👀 Purpose

- To centralise business and validation logic into the `join` route, making our security checks around the join process clearer
- To remove business logic from the Authentication process, making the code more transposable for other solutions
- To increase security by adding additional validation checks for user input

## ♻️ What's changed

- Removed all validation logic from the auth route, clarifying it's the responsibility of only communicating with Auth0 to generate a session token
- Created an Auth0 Service layer, to clarify and separate the responsibility of the route (accepting requestions and storing the session) from the actual communication with Auth0 (or our auth provider)
- Moved all validation checks into the join route, and re-used them in the code where appropriate 
- Added a new `/send-invitation` route - which (should) contain all previous checks and final validation checks before sending the invitation. The route feels very clear in terms of highlighting exactly how we validate the data - but it'd be good to hear others thoughts! 🧠 🤏 
- Added a new error handler to display a useful page to users if something goes due to their input i.e. input email doesn't match the authenticated email
- Refactored some tests since they failed due to the new validation checks
- Refactored test structure of the join route from `test_views` to `routes/test_join`
- Added the `session.clear()` at the end of the route - worth noting that the `/auth/logout` wasn't and still isn't being used. So we're still not clearing the session with Auth0 🙈 but at least this PR clears the session at the end of the journey 🧼 

## 📝 Notes

- There's still some more test cases that need adding - but I believe the PR is getting a bit too big at this point 😬 so I'll add the test cases as a new PR for some of the functionality
- Ideally, we should be clearing the session with Auth0 as well at the end of the journey - this is possible, but would of required some additional movement of some code, so thought I'd leave that for a separate PR