### PR TITLE
:recycle: Additional Organisation Information

### DIFF
--- a/app/templates/pages/home.html
+++ b/app/templates/pages/home.html
@@ -10,8 +10,31 @@
 <p class="govuk-body">
     Use this service to request access to one or both of the Ministry of Justice GitHub Organisations:
     <ul class="govuk-list govuk-list--bullet">
-        <li><a class="govuk-link" href="https://github.com/ministryofjustice">Ministry of Justice</a></li>
-        <li><a class="govuk-link" href="https://github.com/moj-analytical-services">MoJ Analytical Services</a></li>
+        <details class="govuk-details">
+            <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                Ministry of Justice
+                </span>
+            </summary>
+            <div class="govuk-details__text">
+                <li>access to MoJ application code/repositories</li>
+                <li>access to MoJ Cloud Platform</li>
+                <li>access to MoJ Modernisation Platform</li>
+                <li>access to and AWS using Single Sign-on (AWS SSO)</li>
+            </div>
+        </details>
+        <details class="govuk-details">
+            <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                MoJ Analytical Services
+                </span>
+            </summary>
+            <div class="govuk-details__text">
+                <li>access to Analytical Services application code/repositories</li>
+                <li>access to MoJ Analytical Platform</li>
+                <li>ability to raise support requests with Analytical Platform Team.</li>
+            </div>
+        </details>
     </ul>
 </p>
 <p class="govuk-body">


### PR DESCRIPTION
## 👀 Purpose

To include additional (optional) detail on each organisation for the user.

## ♻️ What's Changed

The two <li> components have been changed to <detail> components with bullet pointed details about each organisation. These are optionally expandable:

<img width="852" alt="image" src="https://github.com/ministryofjustice/operations-engineering-join-github/assets/124164618/499809a2-2398-4bc1-9eaf-95a027c51250">


## 📝 Notes

No notes to speak of.