### PR TITLE
Update wording on GitHub Organisation Invitation

### DIFF
--- a/app/templates/pages/justice-and-other-user.html
+++ b/app/templates/pages/justice-and-other-user.html
@@ -13,26 +13,24 @@ GitHub Access Invitation
 {% endblock %}
 
 {% block content %}
-<h1 class="govuk-heading-l">GitHub Organisation Invitation</h1>
+<h1 class="govuk-heading-l">Verify your work email address</h1>
 
 <p class="govuk-body">
-  To access the Ministry of Justice GitHub organisations you've selected, your email address <strong>{{email}}</strong>
-  will be verified
-  using Azure Active Directory (AD). This secure step is essential to confirm your identity and initiate the process of
-  joining our GitHub organisations.
+  This secure step is essential to confirm your identity and initiate the process of joining our GitHub organisations<strong>{{email}}</strong>
+
 </p>
 
 <p class="govuk-body">
-  By clicking the button below, you will be redirected to a secure Azure AD login page for authentication.
+  By clicking the button below, you will be redirected to a secure sign-on page where you will be asked to confirm your Office 365 login details.
 </p>
 
 <p class="govuk-body">
-  After successfully authenticating with your @justice.gov.uk credentials, GitHub will send an invitation to
+  After successfully authenticating with your @justice.gov.uk credentials, GitHub will send an invitation to your work email address.
   <strong>{{email}}</strong>. You will need to accept this invitation to join the selected GitHub organisation.
 </p>
 
 <form action="/auth/login" method="get">
-  <button type="submit" class="govuk-button">Authenticate {{ email }}</button>
+  <button type="submit" class="govuk-button">verify </button>
 </form>
 
 <p class="govuk-body">

--- a/app/templates/pages/justice-and-other-user.html
+++ b/app/templates/pages/justice-and-other-user.html
@@ -16,7 +16,7 @@ GitHub Access Invitation
 <h1 class="govuk-heading-l">Verify your work email address</h1>
 
 <p class="govuk-body">
-  This secure step is essential to confirm your identity and initiate the process of joining our GitHub organisations<strong>{{email}}</strong>
+  This secure step is essential to confirm your identity and initiate the process of joining our GitHub organisations.
 </p>
 
 <p class="govuk-body">
@@ -25,7 +25,7 @@ GitHub Access Invitation
 
 <p class="govuk-body">
   After successfully authenticating with your @justice.gov.uk credentials, GitHub will send an invitation to your work email address.
-  <strong>{{email}}</strong>. You will need to accept this invitation to join the selected GitHub organisation.
+  
 </p>
 
 <form action="/auth/login" method="get">

--- a/app/templates/pages/justice-and-other-user.html
+++ b/app/templates/pages/justice-and-other-user.html
@@ -17,7 +17,6 @@ GitHub Access Invitation
 
 <p class="govuk-body">
   This secure step is essential to confirm your identity and initiate the process of joining our GitHub organisations<strong>{{email}}</strong>
-
 </p>
 
 <p class="govuk-body">


### PR DESCRIPTION
The page title ("GitHub Organisation Invitation") doesn't explain what this page is for. change to "Verify your work email address.

Replace "To access the Ministry of Justice GitHub organisations you've selected, your email address @justice.gov.uk will be verified using Azure Active Directory (AD).

This secure step is essential to confirm your identity and initiate the process of joining our GitHub organisations
By clicking the button below, you will be redirected to a secure sign-on page where you will be asked to confirm your Office 365 login details

"After successful verification, a GitHub invitation will be sent to your work email address. You will need to accept this invitation to join the selected GitHub organisation

Replace button text "Authenticate" to verify


