### PR TITLE
Delete line requested get azure ad creds

### DIFF
--- a/app/templates/pages/home.html
+++ b/app/templates/pages/home.html
@@ -41,8 +41,7 @@
     You will need the following:
 </p>
 <ul class="govuk-list govuk-list--bullet">
-    <li>The email address you wish to join with</li>
-    <li>Your login details for Ministry of Justice Azure AD authentication</li>
+    <li>The work email address you wish to join with</li>
 </ul>
 <p class="govuk-body">
 Joining takes around 5  minutes.


### PR DESCRIPTION
Azure AD creds are not required by everyone, it depends what work email you use and this is explained later. This request on the home page is potentially misleading.