### PR TITLE
🐛 Handle GitHub Validation Failure if User Exists

### DIFF
--- a/app/main/routes/join.py
+++ b/app/main/routes/join.py
@@ -127,7 +127,8 @@ def send_invitation():
 
     if not is_pre_approved_email_domain(auth0_email):
         logger.error("Email domain is not pre-approved")
-        abort(400, f"Email {auth0_email} is not pre-approved")
+        abort(400, f"Email {
+              auth0_email} is not pre-approved")
 
     try:
         current_app.github_service.send_invites_to_user_email(
@@ -136,12 +137,13 @@ def send_invitation():
         if "A user with this email address is already a part of this organization" in str(e):
             logger.error(
                 "User %s is already a member of the organization.", auth0_email)
-            return "User is already a member of the organization", 200
+            abort(400,
+                  f"User {auth0_email} is already a member of the organization.")
         # re-raise the exception if it's a different error
         logger.error("An unexpected GithubException occurred: %s", str(e))
         raise e
     except ValueError:
-        current_app.logger.error(f"Invalid email address: {auth0_email}")
+        logger.error("Invalid email address: %s", auth0_email)
 
     return redirect(url_for("join_route.invitation_sent"))
 
@@ -179,7 +181,7 @@ def sanitise_org_selection(org_selection: list[str]) -> list[str]:
 
 
 def is_pre_approved_email_domain(email: str) -> bool:
-    domain = email[email.index("@")+1:]
+    domain = email[email.index("@") + 1:]
     return domain in app_config.github.allowed_email_domains
 
 

--- a/app/main/routes/join.py
+++ b/app/main/routes/join.py
@@ -122,8 +122,7 @@ def send_invitation():
 
     if user_input_email != auth0_email:
         logger.error("Initial email does not match authenticated email")
-        abort(400,
-              f"Initial email {user_input_email} does not match authenticated email {auth0_email}")
+        abort(400,f"Initial email {user_input_email} does not match authenticated email {auth0_email}")
 
     if not is_pre_approved_email_domain(auth0_email):
         logger.error("Email domain is not pre-approved")

--- a/app/main/routes/join.py
+++ b/app/main/routes/join.py
@@ -137,13 +137,13 @@ def send_invitation():
         if "A user with this email address is already a part of this organization" in str(e):
             logger.error(
                 "User %s is already a member of the organization.", auth0_email)
-            abort(400,
-                  f"User {auth0_email} is already a member of the organization.")
+            return render_template(
+                "pages/already-a-member.html",
+                email=auth0_email,
+            )
         # re-raise the exception if it's a different error
         logger.error("An unexpected GithubException occurred: %s", str(e))
         raise e
-    except ValueError:
-        logger.error("Invalid email address: %s", auth0_email)
 
     return redirect(url_for("join_route.invitation_sent"))
 

--- a/app/main/routes/join.py
+++ b/app/main/routes/join.py
@@ -122,8 +122,8 @@ def send_invitation():
 
     if user_input_email != auth0_email:
         logger.error("Initial email does not match authenticated email")
-        abort(400, f"Initial email {
-              user_input_email} does not match authenticated email {auth0_email}")
+        abort(400,
+              f"Initial email {user_input_email} does not match authenticated email {auth0_email}")
 
     if not is_pre_approved_email_domain(auth0_email):
         logger.error("Email domain is not pre-approved")

--- a/app/main/routes/join.py
+++ b/app/main/routes/join.py
@@ -127,8 +127,7 @@ def send_invitation():
 
     if not is_pre_approved_email_domain(auth0_email):
         logger.error("Email domain is not pre-approved")
-        abort(400, f"Email {
-              auth0_email} is not pre-approved")
+        abort(400, f"Email {auth0_email} is not pre-approved")
 
     try:
         current_app.github_service.send_invites_to_user_email(

--- a/app/templates/pages/already-a-member.html
+++ b/app/templates/pages/already-a-member.html
@@ -15,7 +15,7 @@ Already a Member
 {% block content %}
 
 {{ govukPanel({
-'titleText': 'It appears you are already a member of the MoJ GitHub Organisation. Please sign in to GitHub and check
+'titleText': 'It appears you are already a member of the MoJ GitHub Organisation you attempted to join. Please sign in to GitHub and check
 your organisation memberships. If you are still experiencing issues, please contact the Operations Engineering team.',
 'html': email
 }) }}

--- a/app/templates/pages/already-a-member.html
+++ b/app/templates/pages/already-a-member.html
@@ -1,0 +1,28 @@
+{% extends "components/base.html" %}
+
+{% block pageTitle %}
+Already a Member
+{% endblock %}
+
+{% block beforeContent %}
+{{ super() }}
+{{ govukBackLink ({
+'text': 'Back',
+'href': '/'
+}) }}
+{% endblock %}
+
+{% block content %}
+
+{{ govukPanel({
+'titleText': 'It appears you are already a member of the MoJ GitHub Organisation. Please sign in to GitHub and check
+your organisation memberships. If you are still experiencing issues, please contact the Operations Engineering team.',
+'html': email
+}) }}
+
+<p class="govuk-body">
+  If you require further assistance contact us on the Operations Engineering team Slack channel <a
+    href="https://mojdt.slack.com/archives/C01BUKJSZD4" class="govuk-link">#ask-operations-engineering</a>.
+</p>
+
+{% endblock %}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
       MOJ_ORG_ENABLED: "true"
       MOJ_AS_ORG_ENABLED: "true"
       MOJ_TEST_ORG_ENABLED: "true"
-      SEND_EMAIL_INVITES: "true"
+      SEND_EMAIL_INVITES: "false"
       PHASE_BANNER_TEXT: "LOCAL DEV"
       LOGGING_LEVEL: "DEBUG"
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,17 +15,17 @@ services:
 
       # Flask
       APP_SECRET_KEY: dev
-      FLASK_DEBUG: true
+      FLASK_DEBUG: "true"
 
       # Sentry
-      # SENTRY_DSN_KEY: 
+      # SENTRY_DSN_KEY:
       SENTRY_ENV: local
 
       # App
-      MOJ_ORG_ENABLED: true
-      MOJ_AS_ORG_ENABLED: true
-      MOJ_TEST_ORG_ENABLED: true
-      SEND_EMAIL_INVITES: false
+      MOJ_ORG_ENABLED: "true"
+      MOJ_AS_ORG_ENABLED: "true"
+      MOJ_TEST_ORG_ENABLED: "true"
+      SEND_EMAIL_INVITES: "true"
       PHASE_BANNER_TEXT: "LOCAL DEV"
       LOGGING_LEVEL: "DEBUG"
     ports:

--- a/tests/routes/test_join.py
+++ b/tests/routes/test_join.py
@@ -32,8 +32,7 @@ class TestSubmitEmail(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.request.path, "/join/submit-email")
-        self.assertEqual(flashed_message.get(
-            "message"), expected_flashed_message)
+        self.assertEqual(flashed_message.get("message"), expected_flashed_message)
 
     def test_redirects_to_select_organisation_when_email_is_pre_approved(self):
         form_data = {"emailAddress": "email@digital.justice.gov.uk"}
@@ -44,8 +43,7 @@ class TestSubmitEmail(unittest.TestCase):
 
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.request.path, "/join/submit-email")
-        self.assertEqual(
-            response.headers["Location"], "/join/select-organisations")
+        self.assertEqual(response.headers["Location"], "/join/select-organisations")
         self.assertEqual(flashed_message.get("message"), None)
 
     def test_redirects_to_outside_collaborators_when_email_is_not_pre_approved(self):
@@ -57,8 +55,7 @@ class TestSubmitEmail(unittest.TestCase):
 
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.request.path, "/join/submit-email")
-        self.assertEqual(
-            response.headers["Location"], "/join/outside-collaborator")
+        self.assertEqual(response.headers["Location"], "/join/outside-collaborator")
         self.assertEqual(flashed_message.get("message"), None)
 
 
@@ -253,9 +250,7 @@ class TestInvitationSent(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.request.path, "/join/invitation-sent")
         self.assertIn("Invitations sent to", str(response.data))
-        self.assertIn(
-            "ministryofjustice and moj-analytical-services", str(response.data)
-        )
+        self.assertIn("ministryofjustice and moj-analytical-services", str(response.data))
 
 
 if __name__ == "__main__":

--- a/tests/routes/test_join.py
+++ b/tests/routes/test_join.py
@@ -198,7 +198,7 @@ class TestInvitationSent(unittest.TestCase):
         self.app.config["SECRET_KEY"] = "test_flask"
         self.client = self.app.test_client()
 
-    @ patch(
+    @patch(
         "app.main.routes.join.app_config",
         new=SimpleNamespace(
             github=SimpleNamespace(
@@ -223,7 +223,7 @@ class TestInvitationSent(unittest.TestCase):
         self.assertEqual(response.request.path, "/join/invitation-sent")
         self.assertIn("ministryofjustice", str(response.data))
 
-    @ patch(
+    @patch(
         "app.main.routes.join.app_config",
         new=SimpleNamespace(
             github=SimpleNamespace(

--- a/tests/routes/test_join.py
+++ b/tests/routes/test_join.py
@@ -184,9 +184,11 @@ class TestSendInvitations(unittest.TestCase):
             sess["org_selection"] = ["ministryofjustice"]
 
         response = self.client.get("/join/send-invitation")
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.request.path, "/join/send-invitation")
         self.assertIn(
-            "User test@justice.gov.uk is already a member of the organization.", response.data.decode())
+            "It appears you are already a member", str(
+                response.data))
 
 
 class TestInvitationSent(unittest.TestCase):
@@ -196,7 +198,7 @@ class TestInvitationSent(unittest.TestCase):
         self.app.config["SECRET_KEY"] = "test_flask"
         self.client = self.app.test_client()
 
-    @patch(
+    @ patch(
         "app.main.routes.join.app_config",
         new=SimpleNamespace(
             github=SimpleNamespace(
@@ -221,7 +223,7 @@ class TestInvitationSent(unittest.TestCase):
         self.assertEqual(response.request.path, "/join/invitation-sent")
         self.assertIn("ministryofjustice", str(response.data))
 
-    @patch(
+    @ patch(
         "app.main.routes.join.app_config",
         new=SimpleNamespace(
             github=SimpleNamespace(

--- a/tests/routes/test_join.py
+++ b/tests/routes/test_join.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from flask import get_flashed_messages
+from github import GithubException
 
 from app.app import create_app
 from app.main.services.github_service import GithubService
@@ -31,7 +32,8 @@ class TestSubmitEmail(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.request.path, "/join/submit-email")
-        self.assertEqual(flashed_message.get("message"), expected_flashed_message)
+        self.assertEqual(flashed_message.get(
+            "message"), expected_flashed_message)
 
     def test_redirects_to_select_organisation_when_email_is_pre_approved(self):
         form_data = {"emailAddress": "email@digital.justice.gov.uk"}
@@ -42,7 +44,8 @@ class TestSubmitEmail(unittest.TestCase):
 
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.request.path, "/join/submit-email")
-        self.assertEqual(response.headers["Location"], "/join/select-organisations")
+        self.assertEqual(
+            response.headers["Location"], "/join/select-organisations")
         self.assertEqual(flashed_message.get("message"), None)
 
     def test_redirects_to_outside_collaborators_when_email_is_not_pre_approved(self):
@@ -54,7 +57,8 @@ class TestSubmitEmail(unittest.TestCase):
 
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.request.path, "/join/submit-email")
-        self.assertEqual(response.headers["Location"], "/join/outside-collaborator")
+        self.assertEqual(
+            response.headers["Location"], "/join/outside-collaborator")
         self.assertEqual(flashed_message.get("message"), None)
 
 
@@ -130,6 +134,56 @@ class TestSelection(unittest.TestCase):
         self.assertIn("Office 365", str(response.data))
 
 
+class TestSendInvitations(unittest.TestCase):
+    def setUp(self):
+        self.github_service = MagicMock(GithubService)
+        self.app = create_app(self.github_service, False)
+        self.app.config["SECRET_KEY"] = "test_flask"
+        self.client = self.app.test_client()
+
+    @patch(
+        "app.main.routes.join.app_config",
+        new=SimpleNamespace(
+            github=SimpleNamespace(
+                organisations=[
+                    SimpleNamespace(
+                        name="ministryofjustice",
+                        enabled=True,
+                        display_text="Ministry of Justice",
+                    )
+                ]
+            )
+        ),
+    )
+    def test_when_user_is_already_member_of_an_org(self):
+
+        self.github_service.send_invites_to_user_email.side_effect = GithubException(
+            status=422,
+            data={
+                "message": "Validation Failed",
+                "errors": [
+                    {
+                        "resource": "OrganizationInvitation",
+                        "code": "unprocessable",
+                        "field": "data",
+                        "message": "A user with this email address is already a part of this organization"
+                    }
+                ],
+                "documentation_url": "https://docs.github.com/rest/orgs/members#create-an-organization-invitation"
+            }
+        )
+
+        with self.client.session_transaction() as sess:
+            sess["user"] = {"userinfo": {"email": "test@justice.gov.uk"}}
+            sess["user_input_email"] = "test@justice.gov.uk"
+            sess["org_selection"] = ["ministryofjustice"]
+
+        response = self.client.get("/join/send-invitation")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            "User test@justice.gov.uk is already a member of the organization.", response.data.decode())
+
+
 class TestInvitationSent(unittest.TestCase):
     def setUp(self):
         self.github_service = MagicMock(GithubService)
@@ -184,7 +238,8 @@ class TestInvitationSent(unittest.TestCase):
     def test_multiple_invitations_sent(self):
         with self.client.session_transaction() as sess:
             sess["user"] = {"userinfo": {"email": "test@justice.gov.uk"}}
-            sess["org_selection"] = ["ministryofjustice", "moj-analytical-services"]
+            sess["org_selection"] = [
+                "ministryofjustice", "moj-analytical-services"]
 
         response = self.client.get("/join/invitation-sent")
 


### PR DESCRIPTION
## 👀 Purpose

- This PR connects to https://github.com/ministryofjustice/operations-engineering/issues/4507 and relates to a 500 internal server error that appears when a user tries to join an organisation they are already a part of.

## ♻️ What's changed

- Introduced a new error handling method when a user tries to join an organisation they're already part of. Instead of returning an abort statement with a 500 status code, the update now renders a custom page (`already-a-member.html`) informing the user that they are already a member in a more user-friendly way.
- Boolean environment variables in the docker-compose.yaml have been updated from `true/false` to "true"/"false". This change ensures compatibility with systems that require string-type environment variables.