### PR TITLE
⬆️ Upgrade Authlib Package and Create Trivy Scan Options

### DIFF
--- a/.github/workflows/trivy-container-scan.yml
+++ b/.github/workflows/trivy-container-scan.yml
@@ -1,0 +1,79 @@
+name: Scan Container for Vulnerabilities
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1" # At 06:00 on Monday.
+
+jobs:
+  CVE-scan:
+    runs-on: ubuntu-latest
+    environment: dev
+    permissions:
+      issues: write
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
+
+      - name: Build the Docker image
+        run: "docker build . --tag localbuild/testimage:latest"
+
+      - name: Trivy scan
+        id: scan
+        uses: aquasecurity/trivy-action@d43c1f16c00cfd3978dde6c07f4bbcf9eb6993ca # v0.16.1
+        with:
+          image-ref: "localbuild/testimage:latest"
+          format: "sarif"
+          output: "results.sarif"
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: "results.sarif"
+
+      - name: CVE Description escaped extraction and print
+        run: |
+          SCAN_RESULTS=$(jq -r '.runs[0].tool.driver.rules | map(.help.text) | join("\\n")' results.sarif)
+          echo "CVE_CRITICAL=$(echo $SCAN_RESULTS | grep -o CRITICAL | wc -l)" >> $GITHUB_ENV
+          echo "CVE_HIGH=$(echo $SCAN_RESULTS | grep -o HIGH | wc -l)" >> $GITHUB_ENV
+          echo "CVE_MEDIUM=$(echo $SCAN_RESULTS | grep -o MEDIUM | wc -l)" >> $GITHUB_ENV
+
+          echo $SCAN_RESULTS
+
+      - name: Fails if CVE HIGH or CRITICAL are detected
+        id: cve-threshold
+        if: env.CVE_HIGH > 0 || env.CVE_CRITICAL > 0
+        run: exit 1
+
+      - name: Send notification to Slack
+        id: slack
+        if: always() && github.event_name == 'schedule' && steps.cve-threshold.outcome == 'failure'
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 #v1.24.0
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "[ ${{ github.event.repository.name }} ]"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": " `CRITICAL` : *${{ env.CVE_CRITICAL }}*\n\n`HIGH` : *${{ env.CVE_HIGH }}*\n\n`MEDIUM` : *${{ env.CVE_MEDIUM }}*\n\n<https://github.com/${{ github.repository }}/security/code-scanning |See details on GitHub>"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.CVE_SCAN_SLACK_WEBHOOK }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/makefile
+++ b/makefile
@@ -56,6 +56,11 @@ local: venv
 docker-up:
 	docker-compose -f docker-compose.yaml up -d
 
+trivy-scan:
+	@echo "Running Trivy scan..."
+	docker build -t localbuild/testimage:latest .
+	trivy image --severity HIGH,CRITICAL localbuild/testimage:latest
+
 all:
 
-.PHONY: venv lint test format local clean-test report all
+.PHONY: trivy-scan venv lint test format local clean-test report all

--- a/makefile
+++ b/makefile
@@ -1,15 +1,6 @@
 .ONESHELL:
 
 PYTHON_SOURCE_FILES = ./tests operations_engineering_join_github.py ./app
-# Default values for variables (can be overridden by passing arguments to `make`)
-RELEASE_NAME ?= default-release-name
-AUTH0_CLIENT_ID ?= default-auth0-client-id
-AUTH0_CLIENT_SECRET ?= default-auth0-client-secret
-APP_SECRET_KEY ?= default-app-secret-key
-API_KEY ?= default-api-key
-HOST_NAME?= default-host-suffix
-IMAGE ?= default-image
-REGISTRY ?= default-registry
 
 help:
 	@echo "Available commands:"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Production
-authlib==1.3.0
+authlib==1.3.1
 email-validator==2.1.0.post1
 flask==3.0.2
 flask-cors==4.0.1


### PR DESCRIPTION
## 👀 Purpose

- This PR responds to the dependabot scan https://github.com/ministryofjustice/operations-engineering-join-github/security/dependabot/5.
- It bumps the Authlib to 1.3.1 and adds options to run a Trivy scan either locally or via a workflow pipeline.
- The pipeline is triggered either manually or weekly at 0600 on a Monday.

## ♻️ What's changed

- A dependency bump to patch a High CVE.
- An entry in the makefile containing quick options to run a Trivy scan with some relevant arguments.
- A new github-workflow that scans the Dockerfile once a week.
