### PR TITLE
:arrow_up: Bump flask-cors version to 5.0.0 to mitigate CVE

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 authlib==1.3.1
 email-validator==2.1.0.post1
 flask==3.0.2
-flask-cors==4.0.1
+flask-cors==5.0.0
 Flask-Limiter==3.5.0
 govuk-frontend-jinja==3.0.0
 gunicorn==22.0.0


### PR DESCRIPTION
This commit connects to https://github.com/ministryofjustice/operations-engineering/issues/4809
