### PR TITLE
:arrow_up: Bump setuptools to 70.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ gunicorn==22.0.0
 PyGithub==2.1.1
 requests==2.32.0
 sentry-sdk==2.8.0
+setuptools==70.0.0
 
 # Development
 freezegun==1.5.1


### PR DESCRIPTION
This mitigates https://avd.aquasec.com/nvd/2024/cve-2024-6345/
